### PR TITLE
SOE-1594: fix non-responsive image

### DIFF
--- a/css/stanford_news_layouts.css
+++ b/css/stanford_news_layouts.css
@@ -173,7 +173,7 @@
 
 .node-type-stanford-news-item .group-s-caption-style.field-group-div.caption,
 .node-type-stanford-news-item .group-s-credits-style.field-group-div.credits {
-  display: inline-block;
+  display: inline;
 }
 
 @media (max-width: 550px) {
@@ -182,14 +182,23 @@
     display: block;
   }
 }
+@media (min-width: 790px) {
+  .node-type-stanford-news-item .postcard-image {
+    width: 700px;
+}
 
-.node-type-stanford-news-item .postcard-image {
-  width: 850px;
+@media (min-width: 980px) {
+  .node-type-stanford-news-item .postcard-image {
+    width: 850px;
 }
 
 .node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-caption-style.field-group-div.caption, 
 .node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-caption-style.field-group-div.caption .field-name-field-s-image-caption,
 .node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits,
+.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-items,
+.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-item,
+.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-items .field-item.even,
+.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-items .field-item.odd,
 .node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-name-field-s-image-credits,
 .node-type-stanford-news-item .field-name-field-s-image-info .content .field-items,
 .node-type-stanford-news-item .field-name-field-s-image-info .content .field-item,

--- a/css/stanford_news_layouts.css
+++ b/css/stanford_news_layouts.css
@@ -142,18 +142,12 @@
   margin-top: 1em;
 }
 
-.node-type-stanford-news-item .content-body .field-name-field-s-image-caption,
-.node-type-stanford-news-item .field-name-field-s-image-caption p {
-  margin-bottom: 0;
-}
-
 .node-type-stanford-news-item .caption {
   font-size: .7em;
   font-style: normal;
 }
 
 .node-type-stanford-news-item .caption p:after {
-  content: " |";
   padding-right: 3px;
 }
 
@@ -190,20 +184,6 @@
 @media (min-width: 980px) {
   .node-type-stanford-news-item .postcard-image {
     width: 850px;
-}
-
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-caption-style.field-group-div.caption, 
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-caption-style.field-group-div.caption .field-name-field-s-image-caption,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-items,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-item,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-items .field-item.even,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-items .field-item.odd,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-name-field-s-image-credits,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .field-items,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .field-item,
-.node-type-stanford-news-item .field-name-field-s-image-info .content p { 
-  display: inline; 
 }
 
 /* BODY CONTENT STYLES */

--- a/css/stanford_news_layouts.css
+++ b/css/stanford_news_layouts.css
@@ -165,20 +165,11 @@
   line-height: 1.5em;
 }
 
-.node-type-stanford-news-item .group-s-caption-style.field-group-div.caption,
-.node-type-stanford-news-item .group-s-credits-style.field-group-div.credits {
-  display: inline;
-}
-
 @media (max-width: 550px) {
   .node-type-stanford-news-item .group-s-caption-style.field-group-div.caption,
   .node-type-stanford-news-item .group-s-credits-style.field-group-div.credits {
     display: block;
   }
-}
-@media (min-width: 790px) {
-  .node-type-stanford-news-item .postcard-image {
-    width: 700px;
 }
 
 @media (min-width: 980px) {

--- a/stanford_soe_helper.info
+++ b/stanford_soe_helper.info
@@ -2,6 +2,7 @@ name = Stanford SOE Helper
 description = Makes modifications to JSE SOE sites.
 core = 7.x
 dependencies[] = css_injector
+dependencies[] = stanford_news_extras
 package = Stanford
 version = 7.x-1.0-dev
 project = stanford_soe_helper

--- a/stanford_soe_helper.module
+++ b/stanford_soe_helper.module
@@ -100,3 +100,16 @@ function stanford_soe_helper_cc() {
   }
   return '';
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter() for stanford_news_item_node_form.
+ */
+function stanford_soe_helper_form_stanford_news_item_node_form_alter(
+  &$form,
+  &$form_state,
+  $form_id) {
+
+  // Handle deprecation of image credits.
+  stanford_news_extras_deprecate_image_credits($form, $form_id);
+}
+


### PR DESCRIPTION
# Purpose
This PR works in conjunction with and depends on 
https://github.com/SU-SWS/stanford_news/pull/46

Since we want to combine caption and credits into a single field,
it works to deprecate the credits field on the news item for news extras. 
If text is in the credits field, that field is displayed. If there's no text then the credits field is not displayed. As well, it changes the title and description for both the caption and credits fields.

# Status
- Ready

# Needed By (Date)
- David said it's GTG

# Urgency
- Client is watching this, and it is for the live SoE site.

# Steps to Test

1. On an SoE dev site put credits into an image field on a news item
2. Pull this onto the site, flush cache
3. Check if the title and help text has changed for both the caption and credits field from  Step 1
4. Edit the news item and remove text from the credits field and save
5. Edit the news item and verify that the credits field *does not* appear.
6. Create a new news item. Verify that credits field *does not* appear.

# Affected Projects or Products
- This PR is dependent upon the news PR:
https://github.com/SU-SWS/stanford_news/pull/46

# Associated Issues
-  https://stanfordits.atlassian.net/browse/SOE-1594
- https://github.com/SU-SWS/stanford_news/pull/46
- https://github.com/SU-SOE/stanford_jumpstart_engineering/pull/30