### PR TITLE
7.x 2.x update color fields

### DIFF
--- a/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.info
+++ b/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.info
@@ -1,0 +1,10 @@
+name = Stanford SoE Helper Bean Types
+description = Customizations for Stanford Bean Types
+core = 7.x
+package = Stanford
+version = 7.x-1.0-alpha1
+project = stanford_soe_helper_bean_types
+dependencies[] = stanford_bean_types
+dependencies[] = stanford_soe_helper_sitewide
+files[] = stanford_soe_helper_bean_types.install
+project status url = https://github.com/SU-SOE/stanford_soe_helper

--- a/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.install
+++ b/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.install
@@ -10,9 +10,9 @@ function stanford_soe_helper_bean_types_install() {
   module_load_include('module', 'stanford_soe_helper_landing_page');
 
   stanford_soe_helper_sitewide_add_tax_field(
-    'field_s_postcard_accent_color',
+    'field_s_postcard_linked_color',
     'soe_accent_color',
-    'stanford_postcard',
+    'stanford_postcard_linked',
     'bean',
     'Arrow accent color');
 }
@@ -41,5 +41,5 @@ function stanford_soe_helper_bean_types_disable() {
  * Implements hook_uninstall().
  */
 function stanford_soe_helper_bean_types_uninstall() {
-  field_delete_field('field_s_postcard_accent_color');
+  field_delete_field('field_s_postcard_color');
 }

--- a/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.install
+++ b/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.install
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @file
+ */
+
+/**
+ * Implements hook_install().
+ */
+function stanford_soe_helper_bean_types_install() {
+  module_load_include('module', 'stanford_soe_helper_landing_page');
+
+  stanford_soe_helper_sitewide_add_tax_field(
+    'field_s_postcard_accent_color',
+    'soe_accent_color',
+    'stanford_postcard',
+    'bean',
+    'Arrow accent color');
+}
+
+/**
+ * Implements hook_enable().
+ */
+function stanford_soe_helper_bean_types_enable() {
+  /*
+   *mymodule_cache_rebuild();
+   */
+  /* Your code here */
+}
+
+/**
+ * Implements hook_disable().
+ */
+function stanford_soe_helper_bean_types_disable() {
+  /*
+   *mymodule_cache_rebuild();
+   */
+  /* Your code here */
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function stanford_soe_helper_bean_types_uninstall() {
+  field_delete_field('field_s_postcard_accent_color');
+}

--- a/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.install
+++ b/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.install
@@ -41,5 +41,8 @@ function stanford_soe_helper_bean_types_disable() {
  * Implements hook_uninstall().
  */
 function stanford_soe_helper_bean_types_uninstall() {
-  field_delete_field('field_s_postcard_color');
+  $field_info_field = field_info_field('field_s_postcard_linked_color');
+  if (!empty($field_info_field)) {
+    field_delete_field('field_s_postcard_linked_color');
+  }
 }

--- a/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.module
+++ b/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.module
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @file
+ * File description
+ *
+ * Long description
+ */
+

--- a/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.module
+++ b/modules/stanford_soe_helper_bean_types/stanford_soe_helper_bean_types.module
@@ -1,8 +1,6 @@
 <?php
 /**
  * @file
- * File description
- *
- * Long description
+ * Code for the Stanford SOE Helper Bean Types module.
  */
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds the accent color taxonomy field to the postcard bean type

# Needed By (Date)

# Urgency

# Steps to Test

Install module
Verify new accent field at _admin/structure/block-types/manage/stanford-postcard/fields_
Uninstall module
Verify accent field has been deleted

# Affected Projects or Products
- SoE

# Associated Issues and/or People
- SOE-1971

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)