### PR TITLE
SOE-2035 SOE-2036 SOE-2037 Dm tweaks

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -3017,12 +3017,15 @@ html.js body > .hero-curtain {
   /* line 29, ../scss/components/_soe_dm_curtain_reveal.scss */
   html.js body > .hero-curtain.below-hero {
     padding-bottom: 0 !important; }
-/* line 34, ../scss/components/_soe_dm_curtain_reveal.scss */
+  /* line 33, ../scss/components/_soe_dm_curtain_reveal.scss */
+  html.js body > .hero-curtain .mag-feat-image-container {
+    background: rgba(0, 0, 0, 0.8); }
+/* line 38, ../scss/components/_soe_dm_curtain_reveal.scss */
 html.js body > .hero-curtain-reveal {
   position: fixed;
   top: 0;
   width: 100%; }
-  /* line 39, ../scss/components/_soe_dm_curtain_reveal.scss */
+  /* line 43, ../scss/components/_soe_dm_curtain_reveal.scss */
   html.js body > .hero-curtain-reveal.below-hero {
     position: relative; }
 

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -3019,7 +3019,7 @@ html.js body > .hero-curtain {
     padding-bottom: 0 !important; }
   /* line 33, ../scss/components/_soe_dm_curtain_reveal.scss */
   html.js body > .hero-curtain .mag-feat-image-container {
-    background: rgba(0, 0, 0, 0.8); }
+    background: #333333; }
 /* line 38, ../scss/components/_soe_dm_curtain_reveal.scss */
 html.js body > .hero-curtain-reveal {
   position: fixed;

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -1163,7 +1163,7 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     /* line 16, ../scss/components/_soe_news.scss */
     .node-type-stanford-news-item .body-style {
       width: 100%; } }
-@media (min-width: 980px) {
+@media (min-width: 979px) {
   /* line 23, ../scss/components/_soe_news.scss */
   .node-type-stanford-news-item .postcard-image {
     width: 850px; } }
@@ -1514,28 +1514,32 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
             #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a:focus, #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a:hover {
               background-color: transparent;
               border-bottom-color: #333333; }
+            /* line 120, ../scss/components/_soe_dm_navigation.scss */
+            #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a.active {
+              color: #686868;
+              border-bottom-color: #333333; }
 
-/* line 129, ../scss/components/_soe_dm_navigation.scss */
+/* line 134, ../scss/components/_soe_dm_navigation.scss */
 #digital-magazine-megamenu .container {
   background-color: #575757; }
-  /* line 133, ../scss/components/_soe_dm_navigation.scss */
+  /* line 138, ../scss/components/_soe_dm_navigation.scss */
   #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content {
     display: flex;
     flex-wrap: wrap;
     text-align: center; }
-    /* line 138, ../scss/components/_soe_dm_navigation.scss */
+    /* line 143, ../scss/components/_soe_dm_navigation.scss */
     #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row {
       width: calc(100% * (1/4) - 2%);
       margin-right: 2%; }
       @media (max-width: 767px) {
-        /* line 138, ../scss/components/_soe_dm_navigation.scss */
+        /* line 143, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row {
           width: calc(100% * (1/2) - 2%); } }
       @media (max-width: 480px) {
-        /* line 138, ../scss/components/_soe_dm_navigation.scss */
+        /* line 143, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row {
           width: 100%; } }
-      /* line 148, ../scss/components/_soe_dm_navigation.scss */
+      /* line 153, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row a {
         color: #FFFFFF;
         font-size: 1em; }

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -1580,7 +1580,11 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   #digital-magazine-menu .block-stanford-search-api h2,
   #digital-magazine-menu .block-stanford-search-api input.btn-search {
     display: none; }
-  /* line 47, ../scss/components/_soe_dm_search.scss */
+  @media (max-width: 767px) {
+    /* line 47, ../scss/components/_soe_dm_search.scss */
+    #digital-magazine-menu .block-stanford-search-api .form-item {
+      margin-top: 26px; } }
+  /* line 53, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu .block-stanford-search-api input[type="text"] {
     font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 1em;
@@ -1592,37 +1596,37 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     padding: 5px 0 0 40px;
     background: url("../img/soe_mag_glass_black.svg") no-repeat 6% 70%; }
     @media (max-width: 767px) {
-      /* line 47, ../scss/components/_soe_dm_search.scss */
+      /* line 53, ../scss/components/_soe_dm_search.scss */
       #digital-magazine-menu .block-stanford-search-api input[type="text"] {
         padding-top: 0; }
-        /* line 60, ../scss/components/_soe_dm_search.scss */
+        /* line 66, ../scss/components/_soe_dm_search.scss */
         #digital-magazine-menu .block-stanford-search-api input[type="text"]:focus {
           padding-top: 10px; } }
-    /* line 65, ../scss/components/_soe_dm_search.scss */
+    /* line 71, ../scss/components/_soe_dm_search.scss */
     .not-logged-in #digital-magazine-menu .block-stanford-search-api input[type="text"] {
       margin-right: -15px; }
-  /* line 70, ../scss/components/_soe_dm_search.scss */
+  /* line 76, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu .block-stanford-search-api .input-medium {
     width: 175px; }
     @media (max-width: 979px) {
-      /* line 70, ../scss/components/_soe_dm_search.scss */
+      /* line 76, ../scss/components/_soe_dm_search.scss */
       #digital-magazine-menu .block-stanford-search-api .input-medium {
         width: 115px; } }
     @media (max-width: 767px) {
-      /* line 70, ../scss/components/_soe_dm_search.scss */
+      /* line 76, ../scss/components/_soe_dm_search.scss */
       #digital-magazine-menu .block-stanford-search-api .input-medium {
         width: 0; }
-        /* line 78, ../scss/components/_soe_dm_search.scss */
+        /* line 84, ../scss/components/_soe_dm_search.scss */
         #digital-magazine-menu .block-stanford-search-api .input-medium:focus {
           width: 250px; } }
-  /* line 84, ../scss/components/_soe_dm_search.scss */
+  /* line 90, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu .block-stanford-search-api input:-ms-input-placeholder {
     color: #333333; }
-  /* line 88, ../scss/components/_soe_dm_search.scss */
+  /* line 94, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu .block-stanford-search-api input::-moz-placeholder {
     color: #333333;
     opacity: 1; }
-  /* line 93, ../scss/components/_soe_dm_search.scss */
+  /* line 99, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu .block-stanford-search-api input::-webkit-input-placeholder {
     color: #333333; }
 

--- a/modules/stanford_soe_helper_mag_views/stanford_soe_helper_mag_views.views_default.inc
+++ b/modules/stanford_soe_helper_mag_views/stanford_soe_helper_mag_views.views_default.inc
@@ -42,7 +42,7 @@ function stanford_soe_helper_mag_views_views_default_views() {
   $handler->display->display_options['header']['area_text_custom']['id'] = 'area_text_custom';
   $handler->display->display_options['header']['area_text_custom']['table'] = 'views';
   $handler->display->display_options['header']['area_text_custom']['field'] = 'area_text_custom';
-  $handler->display->display_options['header']['area_text_custom']['content'] = '<h1>All Issues</h1>';
+  $handler->display->display_options['header']['area_text_custom']['content'] = '<h1>Stanford Engineering Magazine</h1>';
   /* Relationship: Entity Reference: Referenced Entity */
   $handler->display->display_options['relationships']['field_s_mag_issue_featured_target_id']['id'] = 'field_s_mag_issue_featured_target_id';
   $handler->display->display_options['relationships']['field_s_mag_issue_featured_target_id']['table'] = 'field_data_field_s_mag_issue_featured';

--- a/scss/components/_soe_dm_article.scss
+++ b/scss/components/_soe_dm_article.scss
@@ -349,7 +349,7 @@
     width: 50%;
     margin: 0 auto 60px;
     text-align: center;
-    @media (min-width: 1200px) {
+    @include breakpoint-min(large) {
       width: 40%;
     }
     @include breakpoint-max(small) {
@@ -664,7 +664,7 @@
 .page-magazine {
   .main {
     padding-bottom: 0;
-    @media (min-width: 979px) {
+    @include breakpoint-min(medium) {
       padding-top: 100px;
     }
 

--- a/scss/components/_soe_dm_curtain_reveal.scss
+++ b/scss/components/_soe_dm_curtain_reveal.scss
@@ -31,7 +31,7 @@ html.js body > {
     }
 
     .mag-feat-image-container {
-      background: rgba(0, 0, 0, 0.8);
+      background: #333333;
     }
   }
 

--- a/scss/components/_soe_dm_curtain_reveal.scss
+++ b/scss/components/_soe_dm_curtain_reveal.scss
@@ -29,6 +29,10 @@ html.js body > {
     &.below-hero {
       padding-bottom: 0 !important;
     }
+
+    .mag-feat-image-container {
+      background: rgba(0, 0, 0, 0.8);
+    }
   }
 
   .hero-curtain-reveal {

--- a/scss/components/_soe_dm_navigation.scss
+++ b/scss/components/_soe_dm_navigation.scss
@@ -25,7 +25,7 @@
     @include breakpoint-max(small) {
       flex-wrap: nowrap;
     }
-    @media (min-width: 1200px) {
+    @include breakpoint-min(large) {
       margin-left: 74px;
     }
 
@@ -114,6 +114,11 @@
             &:focus,
             &:hover {
               background-color: transparent;
+              border-bottom-color: $primary-color;
+            }
+
+            &.active {
+              color: $gray-orange;
               border-bottom-color: $primary-color;
             }
           }

--- a/scss/components/_soe_dm_search.scss
+++ b/scss/components/_soe_dm_search.scss
@@ -44,6 +44,12 @@
       display: none;
     }
 
+    .form-item {
+      @include breakpoint-max(small) {
+        margin-top: 26px;
+      }
+    }
+
     input[type="text"] {
       font-family: $primary-font;
       font-size: em(22px, 22px);

--- a/scss/components/_soe_global.scss
+++ b/scss/components/_soe_global.scss
@@ -253,7 +253,7 @@ th {
 }
 
 #content.span9 {
-  @media (min-width: 1200px) {
+  @include breakpoint-min(large) {
     width: 740px;
     margin-left: 80px;
   }

--- a/scss/components/_soe_news.scss
+++ b/scss/components/_soe_news.scss
@@ -21,7 +21,7 @@
   }
 
   .postcard-image {
-    @media (min-width: 980px) {
+    @include breakpoint-min(medium) {
       width: 850px;
     }
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added a background color to the hero curtain div to help with slower loading images
- Passed through breakpoint-min mixin in replacement of @media (min-width: X) {}
- Tweaked margin for magnifying glass on tablet and below for DM menu
- Changed "All Issues" wording to "Stanford Engineering Magazine" for the /issue page
- This branch has been pulled to /dev

# Needed By (Date)
- 8/17 (end of sprint)

# Urgency
- No

# Steps to Test
- Pull this branch and test for the above noted items
- (may not be required) revert the Feature

# Affected Projects or Products
- SoE

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-2036
- https://stanfordits.atlassian.net/browse/SOE-2035

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)