### PR TITLE
SOE-2194: Related Articles: retain three-across

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -2427,7 +2427,24 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     .view-stanford-magazine-articles.article-grouping .views-row,
     .view-stanford-magazine-topics.article-grouping .views-row {
       margin-bottom: 20px; } }
-/* line 249, ../scss/components/_soe_dm_article.scss */
+/* line 248, ../scss/components/_soe_dm_article.scss */
+.view-stanford-magazine-article-most-recent.article-grouping.views-grid-three .views-row,
+.view-stanford-magazine-articles.article-grouping.views-grid-three .views-row,
+.view-stanford-magazine-topics.article-grouping.views-grid-three .views-row {
+  margin-right: 2%;
+  width: 31%; }
+  @media (max-width: 581px) {
+    /* line 248, ../scss/components/_soe_dm_article.scss */
+    .view-stanford-magazine-article-most-recent.article-grouping.views-grid-three .views-row,
+    .view-stanford-magazine-articles.article-grouping.views-grid-three .views-row,
+    .view-stanford-magazine-topics.article-grouping.views-grid-three .views-row {
+      width: 100%; } }
+/* line 255, ../scss/components/_soe_dm_article.scss */
+.view-stanford-magazine-article-most-recent.article-grouping.views-grid-three .views-row.views-row-3,
+.view-stanford-magazine-articles.article-grouping.views-grid-three .views-row.views-row-3,
+.view-stanford-magazine-topics.article-grouping.views-grid-three .views-row.views-row-3 {
+  margin-right: 0; }
+/* line 258, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container,
 .view-stanford-magazine-articles.article-grouping .mag-topic-card-container,
 .view-stanford-magazine-topics.article-grouping .mag-topic-card-container {
@@ -2437,21 +2454,21 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 255, ../scss/components/_soe_dm_article.scss */
+  /* line 264, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-date,
   .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-date,
   .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-date {
     color: #686868;
     font-size: 0.9em;
     font-weight: 100; }
-  /* line 261, ../scss/components/_soe_dm_article.scss */
+  /* line 270, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title,
   .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title,
   .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title {
     font-size: 1.3em;
     line-height: 1.3em;
     font-weight: 600; }
-    /* line 266, ../scss/components/_soe_dm_article.scss */
+    /* line 275, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a {
@@ -2459,7 +2476,7 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
       text-decoration: underline;
       -webkit-text-decoration-skip: ink;
       text-decoration-skip: ink; }
-      /* line 271, ../scss/components/_soe_dm_article.scss */
+      /* line 280, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:focus, .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:hover,
       .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:focus,
       .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:hover,
@@ -2467,73 +2484,73 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
       .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:hover {
         -webkit-text-decoration-color: #333333;
         text-decoration-color: #333333; }
-    /* line 277, ../scss/components/_soe_dm_article.scss */
+    /* line 286, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-orange a,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-orange a,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-orange a {
       -webkit-text-decoration-color: #FFBD54;
       text-decoration-color: #FFBD54; }
-    /* line 281, ../scss/components/_soe_dm_article.scss */
+    /* line 290, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-turquoise a,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-turquoise a,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-turquoise a {
       -webkit-text-decoration-color: #00ECE9;
       text-decoration-color: #00ECE9; }
-    /* line 285, ../scss/components/_soe_dm_article.scss */
+    /* line 294, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-pink a,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-pink a,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-pink a {
       -webkit-text-decoration-color: #FF525C;
       text-decoration-color: #FF525C; }
-  /* line 290, ../scss/components/_soe_dm_article.scss */
+  /* line 299, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-topics,
   .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-topics,
   .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-topics {
     font-size: 0.8em;
     line-height: 1.2em;
     margin: 30px 0; }
-  /* line 296, ../scss/components/_soe_dm_article.scss */
+  /* line 305, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue,
   .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue,
   .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue {
     position: absolute;
     bottom: 15px;
     right: 15px; }
-    /* line 301, ../scss/components/_soe_dm_article.scss */
+    /* line 310, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue[class*="mag-issue-color-"],
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue[class*="mag-issue-color-"],
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue[class*="mag-issue-color-"] {
       padding: 0 9px;
       font-size: 0.8em; }
-    /* line 306, ../scss/components/_soe_dm_article.scss */
+    /* line 315, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-orange,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-orange,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-orange {
       background: #FFBD54; }
-    /* line 310, ../scss/components/_soe_dm_article.scss */
+    /* line 319, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-turquoise,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-turquoise,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-turquoise {
       background: #00ECE9; }
-    /* line 314, ../scss/components/_soe_dm_article.scss */
+    /* line 323, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-pink,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-pink,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-pink {
       background: #FF525C; }
-    /* line 318, ../scss/components/_soe_dm_article.scss */
+    /* line 327, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue a,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue a,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue a {
       color: #333333; }
 
-/* line 326, ../scss/components/_soe_dm_article.scss */
+/* line 335, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-topics.most-recent-article {
   margin-top: -30px; }
 
-/* line 333, ../scss/components/_soe_dm_article.scss */
+/* line 342, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page.views-grid-three .views-row {
   margin-bottom: 0; }
-/* line 337, ../scss/components/_soe_dm_article.scss */
+/* line 346, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page h2 {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: #686868;
@@ -2543,32 +2560,32 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   margin: 0 auto 60px;
   text-align: center; }
   @media (min-width: 1200px) {
-    /* line 337, ../scss/components/_soe_dm_article.scss */
+    /* line 346, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page h2 {
       width: 40%; } }
   @media (max-width: 767px) {
-    /* line 337, ../scss/components/_soe_dm_article.scss */
+    /* line 346, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page h2 {
       width: 100%; } }
-/* line 356, ../scss/components/_soe_dm_article.scss */
+/* line 365, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(1), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(1) {
   width: 22.5%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 356, ../scss/components/_soe_dm_article.scss */
+    /* line 365, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(1), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(1) {
       width: 100%;
       margin-right: 0; } }
-/* line 365, ../scss/components/_soe_dm_article.scss */
+/* line 374, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) {
   width: 45%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 365, ../scss/components/_soe_dm_article.scss */
+    /* line 374, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) {
       width: 100%;
       margin-right: 0; } }
-  /* line 374, ../scss/components/_soe_dm_article.scss */
+  /* line 383, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container {
     background: #FFFFFF;
     padding: 50px 30px 30px;
@@ -2576,57 +2593,57 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
     @media (max-width: 979px) {
-      /* line 374, ../scss/components/_soe_dm_article.scss */
+      /* line 383, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container {
         padding: 15px 30px 30px; } }
-    /* line 382, ../scss/components/_soe_dm_article.scss */
+    /* line 391, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date {
       color: #686868;
       font-size: 1em;
       font-weight: 100;
       margin-bottom: 10px; }
       @media (max-width: 979px) {
-        /* line 382, ../scss/components/_soe_dm_article.scss */
+        /* line 391, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date {
           font-size: 0.9em; } }
-    /* line 392, ../scss/components/_soe_dm_article.scss */
+    /* line 401, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title {
       font-size: 1.6em;
       line-height: 1.2em;
       font-weight: 600; }
       @media (max-width: 979px) {
-        /* line 392, ../scss/components/_soe_dm_article.scss */
+        /* line 401, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title {
           font-size: 1.3em;
           line-height: 1.3em; } }
-    /* line 402, ../scss/components/_soe_dm_article.scss */
+    /* line 411, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics {
       font-size: 0.9em;
       line-height: 1.3em;
       margin: 30px 0; }
       @media (max-width: 979px) {
-        /* line 402, ../scss/components/_soe_dm_article.scss */
+        /* line 411, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics {
           font-size: 0.8em;
           line-height: 1.2em; } }
-/* line 415, ../scss/components/_soe_dm_article.scss */
+/* line 424, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(3), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(3) {
   width: 22.5%;
   margin-right: 0; }
   @media (max-width: 979px) {
-    /* line 415, ../scss/components/_soe_dm_article.scss */
+    /* line 424, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(3), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(3) {
       width: 100%; } }
-/* line 428, ../scss/components/_soe_dm_article.scss */
+/* line 437, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) {
   width: 45%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 428, ../scss/components/_soe_dm_article.scss */
+    /* line 437, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) {
       width: 100%;
       margin-right: 0; } }
-  /* line 437, ../scss/components/_soe_dm_article.scss */
+  /* line 446, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container {
     background: #FFFFFF;
     padding: 50px 30px 30px;
@@ -2634,83 +2651,83 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
     @media (max-width: 979px) {
-      /* line 437, ../scss/components/_soe_dm_article.scss */
+      /* line 446, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container {
         padding: 15px 30px 30px; } }
-    /* line 445, ../scss/components/_soe_dm_article.scss */
+    /* line 454, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date {
       color: #686868;
       font-size: 1em;
       font-weight: 100;
       margin-bottom: 10px; }
       @media (max-width: 979px) {
-        /* line 445, ../scss/components/_soe_dm_article.scss */
+        /* line 454, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date {
           font-size: 0.9em; } }
-    /* line 455, ../scss/components/_soe_dm_article.scss */
+    /* line 464, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title {
       font-size: 1.6em;
       line-height: 1.2em;
       font-weight: 600; }
       @media (max-width: 979px) {
-        /* line 455, ../scss/components/_soe_dm_article.scss */
+        /* line 464, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title {
           font-size: 1.3em;
           line-height: 1.3em; } }
-    /* line 465, ../scss/components/_soe_dm_article.scss */
+    /* line 474, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics {
       font-size: 0.9em;
       line-height: 1.3em;
       margin: 30px 0; }
       @media (max-width: 979px) {
-        /* line 465, ../scss/components/_soe_dm_article.scss */
+        /* line 474, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics {
           font-size: 0.8em;
           line-height: 1.2em; } }
-/* line 478, ../scss/components/_soe_dm_article.scss */
+/* line 487, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(2), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(2) {
   width: 22.5%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 478, ../scss/components/_soe_dm_article.scss */
+    /* line 487, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(2), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(2) {
       width: 100%;
       margin-right: 0; } }
-/* line 487, ../scss/components/_soe_dm_article.scss */
+/* line 496, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(3), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(3) {
   width: 22.5%;
   margin-right: 0; }
   @media (max-width: 979px) {
-    /* line 487, ../scss/components/_soe_dm_article.scss */
+    /* line 496, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(3), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(3) {
       width: 100%; } }
-/* line 499, ../scss/components/_soe_dm_article.scss */
+/* line 508, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(1) {
   width: 22.5%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 499, ../scss/components/_soe_dm_article.scss */
+    /* line 508, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(1) {
       width: 100%;
       margin-right: 0; } }
-/* line 508, ../scss/components/_soe_dm_article.scss */
+/* line 517, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(2) {
   width: 22.5%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 508, ../scss/components/_soe_dm_article.scss */
+    /* line 517, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(2) {
       width: 100%;
       margin-right: 0; } }
-/* line 517, ../scss/components/_soe_dm_article.scss */
+/* line 526, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) {
   width: 45%;
   margin-right: 0; }
   @media (max-width: 979px) {
-    /* line 517, ../scss/components/_soe_dm_article.scss */
+    /* line 526, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) {
       width: 100%; } }
-  /* line 525, ../scss/components/_soe_dm_article.scss */
+  /* line 534, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container {
     background: #FFFFFF;
     padding: 50px 30px 30px;
@@ -2718,51 +2735,51 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
     @media (max-width: 979px) {
-      /* line 525, ../scss/components/_soe_dm_article.scss */
+      /* line 534, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container {
         padding: 15px 30px 30px; } }
-    /* line 533, ../scss/components/_soe_dm_article.scss */
+    /* line 542, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-date {
       color: #686868;
       font-size: 1em;
       font-weight: 100;
       margin-bottom: 10px; }
       @media (max-width: 979px) {
-        /* line 533, ../scss/components/_soe_dm_article.scss */
+        /* line 542, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-date {
           font-size: 0.9em; } }
-    /* line 543, ../scss/components/_soe_dm_article.scss */
+    /* line 552, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-title {
       font-size: 1.6em;
       line-height: 1.2em;
       font-weight: 600; }
       @media (max-width: 979px) {
-        /* line 543, ../scss/components/_soe_dm_article.scss */
+        /* line 552, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-title {
           font-size: 1.3em;
           line-height: 1.3em; } }
-    /* line 553, ../scss/components/_soe_dm_article.scss */
+    /* line 562, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-topics {
       font-size: 0.9em;
       line-height: 1.3em;
       margin: 30px 0; }
       @media (max-width: 979px) {
-        /* line 553, ../scss/components/_soe_dm_article.scss */
+        /* line 562, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-topics {
           font-size: 0.8em;
           line-height: 1.2em; } }
-/* line 568, ../scss/components/_soe_dm_article.scss */
+/* line 577, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page .mag-article-container {
   margin-bottom: 80px; }
   @media (max-width: 979px) {
-    /* line 568, ../scss/components/_soe_dm_article.scss */
+    /* line 577, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container {
       margin-bottom: 40px; } }
   @media (max-width: 979px) {
-    /* line 574, ../scss/components/_soe_dm_article.scss */
+    /* line 583, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-img img {
       width: 100%; } }
-  /* line 580, ../scss/components/_soe_dm_article.scss */
+  /* line 589, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container {
     position: relative;
     background: #FFFFFF;
@@ -2770,90 +2787,90 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-    /* line 586, ../scss/components/_soe_dm_article.scss */
+    /* line 595, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-date {
       color: #686868;
       font-size: 0.9em;
       font-weight: 100; }
-    /* line 592, ../scss/components/_soe_dm_article.scss */
+    /* line 601, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title {
       font-size: 1.3em;
       line-height: 1.3em;
       font-weight: 600; }
-      /* line 597, ../scss/components/_soe_dm_article.scss */
+      /* line 606, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a {
         color: #333333;
         text-decoration: underline;
         -webkit-text-decoration-skip: ink;
         text-decoration-skip: ink; }
-        /* line 602, ../scss/components/_soe_dm_article.scss */
+        /* line 611, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a:focus, .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a:hover {
           -webkit-text-decoration-color: #333333;
           text-decoration-color: #333333; }
-      /* line 608, ../scss/components/_soe_dm_article.scss */
+      /* line 617, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-orange a {
         -webkit-text-decoration-color: #FFBD54;
         text-decoration-color: #FFBD54; }
-      /* line 612, ../scss/components/_soe_dm_article.scss */
+      /* line 621, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-turquoise a {
         -webkit-text-decoration-color: #00ECE9;
         text-decoration-color: #00ECE9; }
-      /* line 616, ../scss/components/_soe_dm_article.scss */
+      /* line 625, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-pink a {
         -webkit-text-decoration-color: #FF525C;
         text-decoration-color: #FF525C; }
-    /* line 621, ../scss/components/_soe_dm_article.scss */
+    /* line 630, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-topics {
       font-size: 0.8em;
       line-height: 1.2em;
       margin: 30px 0; }
-    /* line 627, ../scss/components/_soe_dm_article.scss */
+    /* line 636, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue {
       position: absolute;
       bottom: 15px;
       right: 15px; }
-      /* line 632, ../scss/components/_soe_dm_article.scss */
+      /* line 641, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue[class*="mag-issue-color-"] {
         padding: 0 9px;
         font-size: 0.9em; }
-      /* line 637, ../scss/components/_soe_dm_article.scss */
+      /* line 646, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-orange {
         background: #FFBD54; }
-      /* line 641, ../scss/components/_soe_dm_article.scss */
+      /* line 650, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-turquoise {
         background: #00ECE9; }
-      /* line 645, ../scss/components/_soe_dm_article.scss */
+      /* line 654, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-pink {
         background: #FF525C; }
-      /* line 649, ../scss/components/_soe_dm_article.scss */
+      /* line 658, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue a {
         color: #333333; }
 
-/* line 658, ../scss/components/_soe_dm_article.scss */
+/* line 667, ../scss/components/_soe_dm_article.scss */
 .page-magazine .main {
   padding-bottom: 0; }
   @media (min-width: 979px) {
-    /* line 658, ../scss/components/_soe_dm_article.scss */
+    /* line 667, ../scss/components/_soe_dm_article.scss */
     .page-magazine .main {
       padding-top: 100px; } }
   @media (max-width: 767px) {
-    /* line 664, ../scss/components/_soe_dm_article.scss */
+    /* line 673, ../scss/components/_soe_dm_article.scss */
     .page-magazine .main .container {
       margin-bottom: 0; } }
-  /* line 669, ../scss/components/_soe_dm_article.scss */
+  /* line 678, ../scss/components/_soe_dm_article.scss */
   .page-magazine .main .container .content-head {
     margin-bottom: 0; }
-/* line 675, ../scss/components/_soe_dm_article.scss */
+/* line 684, ../scss/components/_soe_dm_article.scss */
 .page-magazine #page-title {
   text-align: center; }
-/* line 680, ../scss/components/_soe_dm_article.scss */
+/* line 689, ../scss/components/_soe_dm_article.scss */
 .page-magazine .block-stanford-soe-helper-magazine a.btn {
   margin: 0 0 80px; }
 
-/* line 691, ../scss/components/_soe_dm_article.scss */
+/* line 700, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-featured .mag-article-container .mag-article-img img {
   width: 100%; }
-/* line 696, ../scss/components/_soe_dm_article.scss */
+/* line 705, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container {
   background: #FFFFFF;
   padding: 15px 30px 30px;
@@ -2861,77 +2878,77 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
   @media (max-width: 979px) {
-    /* line 696, ../scss/components/_soe_dm_article.scss */
+    /* line 705, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container {
       padding: 15px 30px 30px; } }
-  /* line 704, ../scss/components/_soe_dm_article.scss */
+  /* line 713, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-date {
     color: #686868;
     font-size: 1em;
     font-weight: 100;
     margin-bottom: 10px; }
     @media (max-width: 979px) {
-      /* line 704, ../scss/components/_soe_dm_article.scss */
+      /* line 713, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-date {
         font-size: 0.9em; } }
-  /* line 715, ../scss/components/_soe_dm_article.scss */
+  /* line 724, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-title h2 {
     font-size: 1.4em; }
-    /* line 718, ../scss/components/_soe_dm_article.scss */
+    /* line 727, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-title h2 a {
       -webkit-text-decoration-color: #00ECE9;
       text-decoration-color: #00ECE9; }
-      /* line 721, ../scss/components/_soe_dm_article.scss */
+      /* line 730, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-title h2 a:focus, .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-title h2 a:hover {
         -webkit-text-decoration-color: #333333;
         text-decoration-color: #333333; }
-  /* line 729, ../scss/components/_soe_dm_article.scss */
+  /* line 738, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-topics {
     font-size: 0.9em;
     line-height: 1.3em;
     margin: 30px 0; }
     @media (max-width: 979px) {
-      /* line 729, ../scss/components/_soe_dm_article.scss */
+      /* line 738, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-topics {
         font-size: 0.8em;
         line-height: 1.2em; } }
 
-/* line 745, ../scss/components/_soe_dm_article.scss */
+/* line 754, ../scss/components/_soe_dm_article.scss */
 .node-type-stanford-magazine-article .paragraphs-item-p-two-columns {
   font-family: "Roboto Slab", serif;
   font-size: 1.4em;
   margin-bottom: 1em; }
-/* line 752, ../scss/components/_soe_dm_article.scss */
+/* line 761, ../scss/components/_soe_dm_article.scss */
 .node-type-stanford-magazine-article .paragraphs-item-p-wysiwyg-simple a {
   text-decoration: underline; }
 
-/* line 759, ../scss/components/_soe_dm_article.scss */
+/* line 768, ../scss/components/_soe_dm_article.scss */
 .entity-paragraphs-item iframe {
   width: 100%;
   height: 400px; }
 
-/* line 767, ../scss/components/_soe_dm_article.scss */
+/* line 776, ../scss/components/_soe_dm_article.scss */
 #block-ds-extras-related-departments {
   width: 85%;
   border-top: 1px solid #CCCCCC;
   margin: 0 auto 80px;
   padding-top: 20px; }
   @media (max-width: 480px) {
-    /* line 767, ../scss/components/_soe_dm_article.scss */
+    /* line 776, ../scss/components/_soe_dm_article.scss */
     #block-ds-extras-related-departments {
       width: 100%; } }
-  /* line 776, ../scss/components/_soe_dm_article.scss */
+  /* line 785, ../scss/components/_soe_dm_article.scss */
   #block-ds-extras-related-departments h2 {
     font-size: 0.9em;
     font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
     margin-bottom: 0; }
-  /* line 782, ../scss/components/_soe_dm_article.scss */
+  /* line 791, ../scss/components/_soe_dm_article.scss */
   #block-ds-extras-related-departments .field-name-field-s-mag-article-dept {
     font-size: 0.9em;
     line-height: 1.3em;
     width: 45%; }
     @media (max-width: 480px) {
-      /* line 782, ../scss/components/_soe_dm_article.scss */
+      /* line 791, ../scss/components/_soe_dm_article.scss */
       #block-ds-extras-related-departments .field-name-field-s-mag-article-dept {
         width: 100%; } }
 

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -448,95 +448,95 @@ p.summary.drop-cap:first-letter {
     padding: 13px 0;
     margin-bottom: 0; }
 
-/* line 29, ../scss/components/_soe_brand_bar.scss */
+/* line 28, ../scss/components/_soe_brand_bar.scss */
 #header #logo img {
   max-width: 160px; }
-  /* line 31, ../scss/components/_soe_brand_bar.scss */
+  /* line 30, ../scss/components/_soe_brand_bar.scss */
   .page-magazine #header #logo img,
   #header #logo img .page-magazine-all {
     max-width: 90px; }
     @media (max-width: 767px) {
-      /* line 31, ../scss/components/_soe_brand_bar.scss */
+      /* line 30, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header #logo img,
       #header #logo img .page-magazine-all {
         max-width: 160px; } }
     @media (max-width: 480px) {
-      /* line 31, ../scss/components/_soe_brand_bar.scss */
+      /* line 30, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header #logo img,
       #header #logo img .page-magazine-all {
         max-width: 120px; } }
     @media (max-width: 380px) {
-      /* line 31, ../scss/components/_soe_brand_bar.scss */
+      /* line 30, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header #logo img,
       #header #logo img .page-magazine-all {
         max-width: 80px; } }
-/* line 46, ../scss/components/_soe_brand_bar.scss */
+/* line 45, ../scss/components/_soe_brand_bar.scss */
 #header #logo.logo-mobile {
   padding: 0 5px 0 0; }
   @media (max-width: 480px) {
-    /* line 46, ../scss/components/_soe_brand_bar.scss */
+    /* line 45, ../scss/components/_soe_brand_bar.scss */
     #header #logo.logo-mobile {
       display: table-cell;
       padding: 0 10px 0 0;
       border-right: 1px solid !important; }
-      /* line 53, ../scss/components/_soe_brand_bar.scss */
+      /* line 52, ../scss/components/_soe_brand_bar.scss */
       #header #logo.logo-mobile a {
         background-size: 120px 26.66px; } }
   @media (max-width: 380px) {
-    /* line 58, ../scss/components/_soe_brand_bar.scss */
+    /* line 57, ../scss/components/_soe_brand_bar.scss */
     #header #logo.logo-mobile img {
       max-width: 80px; } }
-/* line 66, ../scss/components/_soe_brand_bar.scss */
+/* line 65, ../scss/components/_soe_brand_bar.scss */
 #header #name-and-slogan.with-logo {
   padding: 0 0 0 5px; }
   @media (max-width: 480px) {
-    /* line 66, ../scss/components/_soe_brand_bar.scss */
+    /* line 65, ../scss/components/_soe_brand_bar.scss */
     #header #name-and-slogan.with-logo {
       display: table-cell;
       padding: 0 0 0 10px; } }
-/* line 74, ../scss/components/_soe_brand_bar.scss */
+/* line 73, ../scss/components/_soe_brand_bar.scss */
 #header.header {
   background: #FFFFFF;
   padding: 20px 0 0;
   min-height: 45px; }
-  /* line 79, ../scss/components/_soe_brand_bar.scss */
+  /* line 78, ../scss/components/_soe_brand_bar.scss */
   #header.header #site-title-first-line.site-title-uppercase {
     font-size: 34px; }
     @media (max-width: 480px) {
-      /* line 79, ../scss/components/_soe_brand_bar.scss */
+      /* line 78, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase {
         font-size: 28px; } }
     @media (max-width: 400px) {
-      /* line 79, ../scss/components/_soe_brand_bar.scss */
+      /* line 78, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase {
         font-size: 24px; } }
     @media (max-width: 380px) {
-      /* line 79, ../scss/components/_soe_brand_bar.scss */
+      /* line 78, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase {
         font-size: 16px;
         margin-bottom: -4px; } }
-  /* line 95, ../scss/components/_soe_brand_bar.scss */
+  /* line 94, ../scss/components/_soe_brand_bar.scss */
   .page-magazine #header.header #site-title-first-line.site-title-uppercase,
   #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
     font-size: 18px;
     margin-bottom: -3px; }
     @media (max-width: 767px) {
-      /* line 95, ../scss/components/_soe_brand_bar.scss */
+      /* line 94, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
       #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
         font-size: 34px; } }
     @media (max-width: 480px) {
-      /* line 95, ../scss/components/_soe_brand_bar.scss */
+      /* line 94, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
       #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
         font-size: 28px; } }
     @media (max-width: 400px) {
-      /* line 95, ../scss/components/_soe_brand_bar.scss */
+      /* line 94, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
       #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
         font-size: 24px; } }
     @media (max-width: 380px) {
-      /* line 95, ../scss/components/_soe_brand_bar.scss */
+      /* line 94, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
       #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
         font-size: 16px; } }
@@ -3494,40 +3494,48 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   @media (max-width: 767px) {
     /* line 567, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issue-recent.views-grid-three .views-row {
-      width: 100%;
-      margin-right: 0; }
+      margin-right: 4%;
+      margin-bottom: 4%; }
       /* line 593, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issue-recent.views-grid-three .views-row:nth-child(3) {
+        margin-right: 4%; } }
+  @media (max-width: 480px) {
+    /* line 567, ../scss/components/_soe_dm_issue.scss */
+    .view-stanford-magazine-issue-recent.views-grid-three .views-row {
+      width: 100%;
+      margin-right: 0; }
+      /* line 601, ../scss/components/_soe_dm_issue.scss */
+      .view-stanford-magazine-issue-recent.views-grid-three .views-row:nth-child(3) {
         margin-right: 0; } }
-/* line 599, ../scss/components/_soe_dm_issue.scss */
+/* line 607, ../scss/components/_soe_dm_issue.scss */
 .view-stanford-magazine-issue-recent h2 {
   text-align: center;
   margin: 1.8em 0 0.2em; }
-/* line 604, ../scss/components/_soe_dm_issue.scss */
+/* line 612, ../scss/components/_soe_dm_issue.scss */
 .view-stanford-magazine-issue-recent h3 {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 400;
   color: #686868;
   text-align: center;
   margin: 0 0 40px; }
-/* line 612, ../scss/components/_soe_dm_issue.scss */
+/* line 620, ../scss/components/_soe_dm_issue.scss */
 .view-stanford-magazine-issue-recent .view-content {
   width: 75%;
   margin: 0 auto; }
   @media (max-width: 979px) {
-    /* line 612, ../scss/components/_soe_dm_issue.scss */
+    /* line 620, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issue-recent .view-content {
       width: 100%; } }
-/* line 620, ../scss/components/_soe_dm_issue.scss */
+/* line 628, ../scss/components/_soe_dm_issue.scss */
 .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper {
   position: relative; }
-  /* line 623, ../scss/components/_soe_dm_issue.scss */
+  /* line 631, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper:hover img {
     -webkit-transform: scale(1.03);
     -moz-transform: scale(1.03);
     -o-transform: scale(1.03);
     transform: scale(1.03); }
-  /* line 627, ../scss/components/_soe_dm_issue.scss */
+  /* line 635, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper .prev-mag-issue-title {
     font-family: "Roboto Slab", serif;
     color: #000000;
@@ -3537,55 +3545,55 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     left: calc(50% - 70px);
     padding: 10px 30px;
     z-index: 1; }
-  /* line 638, ../scss/components/_soe_dm_issue.scss */
+  /* line 646, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper .prev-mag-issue-image {
     overflow: hidden; }
-    /* line 641, ../scss/components/_soe_dm_issue.scss */
+    /* line 649, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper .prev-mag-issue-image img {
       -webkit-transition: all 1s ease;
       -moz-transition: all 1s ease;
       -o-transition: all 1s ease;
       transition: all 1s ease; }
       @media (max-width: 767px) {
-        /* line 641, ../scss/components/_soe_dm_issue.scss */
+        /* line 649, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper .prev-mag-issue-image img {
           width: 100%; } }
-  /* line 649, ../scss/components/_soe_dm_issue.scss */
+  /* line 657, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper.prev-mag-issue-color-orange .prev-mag-issue-title {
     background: #FFBD54; }
-  /* line 653, ../scss/components/_soe_dm_issue.scss */
+  /* line 661, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper.prev-mag-issue-color-turquoise .prev-mag-issue-title {
     background: #00ECE9; }
-  /* line 657, ../scss/components/_soe_dm_issue.scss */
+  /* line 665, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper.prev-mag-issue-color-pink .prev-mag-issue-title {
     background: #FF525C; }
 
-/* line 664, ../scss/components/_soe_dm_issue.scss */
+/* line 672, ../scss/components/_soe_dm_issue.scss */
 .block-stanford-soe-helper-magazine h2 {
   display: none; }
-/* line 668, ../scss/components/_soe_dm_issue.scss */
+/* line 676, ../scss/components/_soe_dm_issue.scss */
 .block-stanford-soe-helper-magazine .soe_block_align {
   text-align: center; }
-  /* line 671, ../scss/components/_soe_dm_issue.scss */
+  /* line 679, ../scss/components/_soe_dm_issue.scss */
   .block-stanford-soe-helper-magazine .soe_block_align a.btn {
     margin: 0 0 80px; }
 
-/* line 681, ../scss/components/_soe_dm_issue.scss */
+/* line 689, ../scss/components/_soe_dm_issue.scss */
 .page-magazine .view-stanford-magazine-issue-most-recent .views-row {
   margin-bottom: 0; }
-/* line 685, ../scss/components/_soe_dm_issue.scss */
+/* line 693, ../scss/components/_soe_dm_issue.scss */
 .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container {
   position: relative; }
-  /* line 688, ../scss/components/_soe_dm_issue.scss */
+  /* line 696, ../scss/components/_soe_dm_issue.scss */
   .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container img {
     object-fit: cover;
     object-position: center center;
     width: 100%;
     height: 100vh; }
-    /* line 694, ../scss/components/_soe_dm_issue.scss */
+    /* line 702, ../scss/components/_soe_dm_issue.scss */
     .logged-in .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container img {
       height: calc(100vh - 75px); }
-  /* line 699, ../scss/components/_soe_dm_issue.scss */
+  /* line 707, ../scss/components/_soe_dm_issue.scss */
   .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container {
     color: #FFFFFF;
     position: absolute;
@@ -3593,7 +3601,7 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     text-align: center;
     width: 100%;
     z-index: 1; }
-    /* line 707, ../scss/components/_soe_dm_issue.scss */
+    /* line 715, ../scss/components/_soe_dm_issue.scss */
     .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1 {
       color: #000000;
       font-size: 1.6em;
@@ -3601,32 +3609,32 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
       padding: 18px 30px;
       background: rgba(0, 0, 0, 0.3); }
       @media (max-width: 767px) {
-        /* line 707, ../scss/components/_soe_dm_issue.scss */
+        /* line 715, ../scss/components/_soe_dm_issue.scss */
         .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1 {
           display: block; } }
-      /* line 717, ../scss/components/_soe_dm_issue.scss */
+      /* line 725, ../scss/components/_soe_dm_issue.scss */
       .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1:after {
         content: url("../img/soe_lg_arrow_right_black.png");
         vertical-align: -6%;
         padding-left: 20px; }
-      /* line 723, ../scss/components/_soe_dm_issue.scss */
+      /* line 731, ../scss/components/_soe_dm_issue.scss */
       .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-orange {
         background: #FFBD54; }
-      /* line 727, ../scss/components/_soe_dm_issue.scss */
+      /* line 735, ../scss/components/_soe_dm_issue.scss */
       .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-turquoise {
         background: #00ECE9; }
-      /* line 731, ../scss/components/_soe_dm_issue.scss */
+      /* line 739, ../scss/components/_soe_dm_issue.scss */
       .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-pink {
         background: #FF525C; }
-    /* line 736, ../scss/components/_soe_dm_issue.scss */
+    /* line 744, ../scss/components/_soe_dm_issue.scss */
     .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container p {
       margin: 10% 0 80px; }
-    /* line 740, ../scss/components/_soe_dm_issue.scss */
+    /* line 748, ../scss/components/_soe_dm_issue.scss */
     .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container:after {
       content: url("../img/soe_chevron_down_white.png");
       position: absolute;
       bottom: 50px; }
-  /* line 747, ../scss/components/_soe_dm_issue.scss */
+  /* line 755, ../scss/components/_soe_dm_issue.scss */
   .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container:after {
     content: '';
     position: absolute;

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -445,97 +445,98 @@ p.summary.drop-cap:first-letter {
         clip-path: inset(0 0 60px 0); } }
   /* line 20, ../scss/components/_soe_brand_bar.scss */
   #global-header .container {
-    padding: 13px 0; }
+    padding: 13px 0;
+    margin-bottom: 0; }
 
-/* line 28, ../scss/components/_soe_brand_bar.scss */
+/* line 29, ../scss/components/_soe_brand_bar.scss */
 #header #logo img {
   max-width: 160px; }
-  /* line 30, ../scss/components/_soe_brand_bar.scss */
+  /* line 31, ../scss/components/_soe_brand_bar.scss */
   .page-magazine #header #logo img,
   #header #logo img .page-magazine-all {
     max-width: 90px; }
     @media (max-width: 767px) {
-      /* line 30, ../scss/components/_soe_brand_bar.scss */
+      /* line 31, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header #logo img,
       #header #logo img .page-magazine-all {
         max-width: 160px; } }
     @media (max-width: 480px) {
-      /* line 30, ../scss/components/_soe_brand_bar.scss */
+      /* line 31, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header #logo img,
       #header #logo img .page-magazine-all {
         max-width: 120px; } }
     @media (max-width: 380px) {
-      /* line 30, ../scss/components/_soe_brand_bar.scss */
+      /* line 31, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header #logo img,
       #header #logo img .page-magazine-all {
         max-width: 80px; } }
-/* line 45, ../scss/components/_soe_brand_bar.scss */
+/* line 46, ../scss/components/_soe_brand_bar.scss */
 #header #logo.logo-mobile {
   padding: 0 5px 0 0; }
   @media (max-width: 480px) {
-    /* line 45, ../scss/components/_soe_brand_bar.scss */
+    /* line 46, ../scss/components/_soe_brand_bar.scss */
     #header #logo.logo-mobile {
       display: table-cell;
       padding: 0 10px 0 0;
       border-right: 1px solid !important; }
-      /* line 52, ../scss/components/_soe_brand_bar.scss */
+      /* line 53, ../scss/components/_soe_brand_bar.scss */
       #header #logo.logo-mobile a {
         background-size: 120px 26.66px; } }
   @media (max-width: 380px) {
-    /* line 57, ../scss/components/_soe_brand_bar.scss */
+    /* line 58, ../scss/components/_soe_brand_bar.scss */
     #header #logo.logo-mobile img {
       max-width: 80px; } }
-/* line 65, ../scss/components/_soe_brand_bar.scss */
+/* line 66, ../scss/components/_soe_brand_bar.scss */
 #header #name-and-slogan.with-logo {
   padding: 0 0 0 5px; }
   @media (max-width: 480px) {
-    /* line 65, ../scss/components/_soe_brand_bar.scss */
+    /* line 66, ../scss/components/_soe_brand_bar.scss */
     #header #name-and-slogan.with-logo {
       display: table-cell;
       padding: 0 0 0 10px; } }
-/* line 73, ../scss/components/_soe_brand_bar.scss */
+/* line 74, ../scss/components/_soe_brand_bar.scss */
 #header.header {
   background: #FFFFFF;
   padding: 20px 0 0;
   min-height: 45px; }
-  /* line 78, ../scss/components/_soe_brand_bar.scss */
+  /* line 79, ../scss/components/_soe_brand_bar.scss */
   #header.header #site-title-first-line.site-title-uppercase {
     font-size: 34px; }
     @media (max-width: 480px) {
-      /* line 78, ../scss/components/_soe_brand_bar.scss */
+      /* line 79, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase {
         font-size: 28px; } }
     @media (max-width: 400px) {
-      /* line 78, ../scss/components/_soe_brand_bar.scss */
+      /* line 79, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase {
         font-size: 24px; } }
     @media (max-width: 380px) {
-      /* line 78, ../scss/components/_soe_brand_bar.scss */
+      /* line 79, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase {
         font-size: 16px;
         margin-bottom: -4px; } }
-  /* line 94, ../scss/components/_soe_brand_bar.scss */
+  /* line 95, ../scss/components/_soe_brand_bar.scss */
   .page-magazine #header.header #site-title-first-line.site-title-uppercase,
   #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
     font-size: 18px;
     margin-bottom: -3px; }
     @media (max-width: 767px) {
-      /* line 94, ../scss/components/_soe_brand_bar.scss */
+      /* line 95, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
       #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
         font-size: 34px; } }
     @media (max-width: 480px) {
-      /* line 94, ../scss/components/_soe_brand_bar.scss */
+      /* line 95, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
       #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
         font-size: 28px; } }
     @media (max-width: 400px) {
-      /* line 94, ../scss/components/_soe_brand_bar.scss */
+      /* line 95, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
       #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
         font-size: 24px; } }
     @media (max-width: 380px) {
-      /* line 94, ../scss/components/_soe_brand_bar.scss */
+      /* line 95, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
       #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
         font-size: 16px; } }

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -453,92 +453,92 @@ p.summary.drop-cap:first-letter {
   max-width: 160px; }
   /* line 30, ../scss/components/_soe_brand_bar.scss */
   .page-magazine #header #logo img,
-  #header #logo img .page-magazine-all {
+  #header #logo img .page-magazine-all, .node-type-stanford-magazine-article #header #logo img {
     max-width: 90px; }
     @media (max-width: 767px) {
       /* line 30, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header #logo img,
-      #header #logo img .page-magazine-all {
+      #header #logo img .page-magazine-all, .node-type-stanford-magazine-article #header #logo img {
         max-width: 160px; } }
     @media (max-width: 480px) {
       /* line 30, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header #logo img,
-      #header #logo img .page-magazine-all {
+      #header #logo img .page-magazine-all, .node-type-stanford-magazine-article #header #logo img {
         max-width: 120px; } }
     @media (max-width: 380px) {
       /* line 30, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header #logo img,
-      #header #logo img .page-magazine-all {
+      #header #logo img .page-magazine-all, .node-type-stanford-magazine-article #header #logo img {
         max-width: 80px; } }
-/* line 45, ../scss/components/_soe_brand_bar.scss */
+/* line 46, ../scss/components/_soe_brand_bar.scss */
 #header #logo.logo-mobile {
   padding: 0 5px 0 0; }
   @media (max-width: 480px) {
-    /* line 45, ../scss/components/_soe_brand_bar.scss */
+    /* line 46, ../scss/components/_soe_brand_bar.scss */
     #header #logo.logo-mobile {
       display: table-cell;
       padding: 0 10px 0 0;
       border-right: 1px solid !important; }
-      /* line 52, ../scss/components/_soe_brand_bar.scss */
+      /* line 53, ../scss/components/_soe_brand_bar.scss */
       #header #logo.logo-mobile a {
         background-size: 120px 26.66px; } }
   @media (max-width: 380px) {
-    /* line 57, ../scss/components/_soe_brand_bar.scss */
+    /* line 58, ../scss/components/_soe_brand_bar.scss */
     #header #logo.logo-mobile img {
       max-width: 80px; } }
-/* line 65, ../scss/components/_soe_brand_bar.scss */
+/* line 66, ../scss/components/_soe_brand_bar.scss */
 #header #name-and-slogan.with-logo {
   padding: 0 0 0 5px; }
   @media (max-width: 480px) {
-    /* line 65, ../scss/components/_soe_brand_bar.scss */
+    /* line 66, ../scss/components/_soe_brand_bar.scss */
     #header #name-and-slogan.with-logo {
       display: table-cell;
       padding: 0 0 0 10px; } }
-/* line 73, ../scss/components/_soe_brand_bar.scss */
+/* line 74, ../scss/components/_soe_brand_bar.scss */
 #header.header {
   background: #FFFFFF;
   padding: 20px 0 0;
   min-height: 45px; }
-  /* line 78, ../scss/components/_soe_brand_bar.scss */
+  /* line 79, ../scss/components/_soe_brand_bar.scss */
   #header.header #site-title-first-line.site-title-uppercase {
     font-size: 34px; }
     @media (max-width: 480px) {
-      /* line 78, ../scss/components/_soe_brand_bar.scss */
+      /* line 79, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase {
         font-size: 28px; } }
     @media (max-width: 400px) {
-      /* line 78, ../scss/components/_soe_brand_bar.scss */
+      /* line 79, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase {
         font-size: 24px; } }
     @media (max-width: 380px) {
-      /* line 78, ../scss/components/_soe_brand_bar.scss */
+      /* line 79, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase {
         font-size: 16px;
         margin-bottom: -4px; } }
-  /* line 94, ../scss/components/_soe_brand_bar.scss */
+  /* line 96, ../scss/components/_soe_brand_bar.scss */
   .page-magazine #header.header #site-title-first-line.site-title-uppercase,
-  #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
+  #header.header .page-magazine-all #site-title-first-line.site-title-uppercase, .node-type-stanford-magazine-article #header.header #site-title-first-line.site-title-uppercase {
     font-size: 18px;
     margin-bottom: -3px; }
     @media (max-width: 767px) {
-      /* line 94, ../scss/components/_soe_brand_bar.scss */
+      /* line 96, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
-      #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
+      #header.header .page-magazine-all #site-title-first-line.site-title-uppercase, .node-type-stanford-magazine-article #header.header #site-title-first-line.site-title-uppercase {
         font-size: 34px; } }
     @media (max-width: 480px) {
-      /* line 94, ../scss/components/_soe_brand_bar.scss */
+      /* line 96, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
-      #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
+      #header.header .page-magazine-all #site-title-first-line.site-title-uppercase, .node-type-stanford-magazine-article #header.header #site-title-first-line.site-title-uppercase {
         font-size: 28px; } }
     @media (max-width: 400px) {
-      /* line 94, ../scss/components/_soe_brand_bar.scss */
+      /* line 96, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
-      #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
+      #header.header .page-magazine-all #site-title-first-line.site-title-uppercase, .node-type-stanford-magazine-article #header.header #site-title-first-line.site-title-uppercase {
         font-size: 24px; } }
     @media (max-width: 380px) {
-      /* line 94, ../scss/components/_soe_brand_bar.scss */
+      /* line 96, ../scss/components/_soe_brand_bar.scss */
       .page-magazine #header.header #site-title-first-line.site-title-uppercase,
-      #header.header .page-magazine-all #site-title-first-line.site-title-uppercase {
+      #header.header .page-magazine-all #site-title-first-line.site-title-uppercase, .node-type-stanford-magazine-article #header.header #site-title-first-line.site-title-uppercase {
         font-size: 16px; } }
 
 /* line 8, ../scss/components/_soe_footer.scss */

--- a/scss/components/_soe_brand_bar.scss
+++ b/scss/components/_soe_brand_bar.scss
@@ -21,7 +21,6 @@
     padding: 13px 0;
     margin-bottom: 0;
   }
-
 }
 
 #header {

--- a/scss/components/_soe_brand_bar.scss
+++ b/scss/components/_soe_brand_bar.scss
@@ -28,7 +28,8 @@
     img {
       max-width: 160px;
       .page-magazine &,
-      .page-magazine-all {
+      .page-magazine-all,
+      .node-type-stanford-magazine-article & {
         max-width: 90px;
         @include breakpoint-max(small) {
           max-width: 160px;
@@ -90,7 +91,8 @@
     }
 
     .page-magazine &,
-    .page-magazine-all {
+    .page-magazine-all,
+    .node-type-stanford-magazine-article & {
       #site-title-first-line.site-title-uppercase {
         font-size: 18px;
         margin-bottom: -3px;

--- a/scss/components/_soe_brand_bar.scss
+++ b/scss/components/_soe_brand_bar.scss
@@ -19,6 +19,7 @@
 
   .container {
     padding: 13px 0;
+    margin-bottom: 0;
   }
 
 }

--- a/scss/components/_soe_dm_article.scss
+++ b/scss/components/_soe_dm_article.scss
@@ -245,7 +245,16 @@
         margin-bottom: 20px;
       }
     }
-
+    &.views-grid-three .views-row {
+        margin-right: 2%;
+        width: 31%;
+        @media (max-width: 581px) {
+          width: 100%;
+        }
+    }
+    &.views-grid-three .views-row.views-row-3 {
+      margin-right: 0;
+    }
     .mag-topic-card-container {
       position: relative;
       background: $white;

--- a/scss/components/_soe_dm_issue.scss
+++ b/scss/components/_soe_dm_issue.scss
@@ -587,6 +587,14 @@
       }
     }
     @include breakpoint-max(small) {
+      margin-right: 4%;
+      margin-bottom: 4%;
+
+      &:nth-child(3) {
+        margin-right: 4%;
+      }
+    }
+    @include breakpoint-max(x-small) {
       width: 100%;
       margin-right: 0;
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary

1.  Magazine Node Related Articles: retain three-across for organization until 581px wide, then jump to single column. See https://sites.stanford.edu/jse-soe/magazine/article/new-semiconductor-materials-exceed-some-silicon-s-secret-powers (Never have two in a row)
2. Magazine grid pages: retain two-column approach for Related Issues section until apr. 400px  https://sites.stanford.edu/jse-soe/magazine
3. Main masthead gap @ 767px: see very faint light gray gap that opens in between the SU red header bar and the main masthead
4. In the footer, the signup button breaks to a new line


# Needed By (Date)
- 

# Criticality
- 

# Steps to Test
1. Verify never have two in a row: Go to /magazine/article/new-semiconductor-materials-exceed-some-silicon-s-secret-powers 
2. Magazine Related Issues retain two-column approach for until apr. 400px https://sites.stanford.edu/jse-soe/magazine
3. Check that the Main masthead gap @ 767px, very faint light gray gap that opens in between the SU red header bar and the main masthead is gone.
4. This was done in a previous ticket.
# Affects 
- SoE

# Associated Issues and/or People
## Related JIRA ticket(s)
- https://stanfordits.atlassian.net/browse/SOE-2194
## Related PRs

## More Information
https://invis.io/WDAOBEJ4P#/230196822_Section_Landing_L-f_04
## Folks to notify


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)