### PR TITLE
max width for footer img logo

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -562,58 +562,62 @@ p.summary.drop-cap:first-letter {
   #footer #block-bean-jumpstart-custom-footer-block,
   #footer #block-bean-jumpstart-links-footer-block {
     margin-bottom: 15px; } }
+/* line 35, ../scss/components/_soe_footer.scss */
+#footer #block-bean-jse-linked-logo-block img {
+  max-width: 270px; }
 @media (max-width: 979px) {
-  /* line 35, ../scss/components/_soe_footer.scss */
+  /* line 39, ../scss/components/_soe_footer.scss */
   #footer #block-stanford-soe-helper-sitewide-stanford-soe-intranet-link {
     margin-top: 50px; } }
 @media (max-width: 767px) {
-  /* line 35, ../scss/components/_soe_footer.scss */
+  /* line 39, ../scss/components/_soe_footer.scss */
   #footer #block-stanford-soe-helper-sitewide-stanford-soe-intranet-link {
     margin-top: 0; } }
-/* line 44, ../scss/components/_soe_footer.scss */
+/* line 48, ../scss/components/_soe_footer.scss */
 #footer #block-bean-jumpstart-footer-social-media-0 {
   float: right;
   width: 22%;
   margin-bottom: 50px; }
   @media (max-width: 1199px) {
-    /* line 44, ../scss/components/_soe_footer.scss */
+    /* line 48, ../scss/components/_soe_footer.scss */
     #footer #block-bean-jumpstart-footer-social-media-0 {
       width: 24%; } }
   @media (max-width: 979px) {
-    /* line 44, ../scss/components/_soe_footer.scss */
+    /* line 48, ../scss/components/_soe_footer.scss */
     #footer #block-bean-jumpstart-footer-social-media-0 {
       float: none;
       width: auto;
       margin-bottom: 30px; } }
-  /* line 58, ../scss/components/_soe_footer.scss */
+  /* line 62, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect a {
     height: 28px;
     background-repeat: no-repeat;
     background-size: auto 28px;
     margin-right: 18px; }
-  /* line 65, ../scss/components/_soe_footer.scss */
+  /* line 69, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect .field-name-field-s-smc-facebook a {
     background-image: url("../img/soe_facebook_icon.png");
     width: 15px; }
-  /* line 70, ../scss/components/_soe_footer.scss */
+  /* line 74, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect .field-name-field-s-smc-twitter a {
     background-image: url("../img/soe_twitter_icon.png");
     width: 35px; }
-  /* line 75, ../scss/components/_soe_footer.scss */
+  /* line 79, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect .field-name-field-s-smc-linkedin a {
     background-image: url("../img/soe_linkedin_icon.png");
     width: 30px; }
-  /* line 80, ../scss/components/_soe_footer.scss */
+  /* line 84, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect .field-name-field-s-smc-youtube a {
     background-image: url("../img/soe_youtube_icon.png");
     width: 40px; }
-  /* line 85, ../scss/components/_soe_footer.scss */
+  /* line 89, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect .field-name-field-s-smc-instagram a {
     background-image: url("../img/soe_instagram_icon.png");
     width: 30px;
     margin-right: 0; }
-/* line 93, ../scss/components/_soe_footer.scss */
-#footer a.private-link, #footer .private-link a {
+/* line 97, ../scss/components/_soe_footer.scss */
+#footer .private-link a,
+#footer a.private-link {
   font-size: 18px;
   font-weight: 400; }
 

--- a/scss/components/_soe_footer.scss
+++ b/scss/components/_soe_footer.scss
@@ -32,6 +32,10 @@
     }
   }
 
+  #block-bean-jse-linked-logo-block img {
+    max-width: 270px;
+  }
+
   #block-stanford-soe-helper-sitewide-stanford-soe-intranet-link {
     @include breakpoint-max(medium) {
       margin-top: 50px;
@@ -90,7 +94,8 @@
     }
   }
 
-  a.private-link, .private-link a {
+  .private-link a,
+  a.private-link {
     font-size: 18px;
     font-weight: 400;
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding a max width to the footer logo image
- This goes hand-in-hand with the PR in for stanford_bean_types

# Needed By (Date)
- Today

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. Verify that the footer logo image has a max width of 270px

# Affected Projects or Products
- SOE
- stanford_soe_helper

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-2030

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)