### PR TITLE
SOE-2222: Added banner image and accent color columns and color filte…

### DIFF
--- a/modules/stanford_soe_helper_page/stanford_soe_helper_page.module
+++ b/modules/stanford_soe_helper_page/stanford_soe_helper_page.module
@@ -5,3 +5,81 @@
  */
 
 include_once 'stanford_soe_helper_page.features.inc';
+/**
+ * Implements hook_views_pre_view().
+ */
+function stanford_soe_helper_page_views_pre_view(&$view, &$display_id, &$args) {
+  if ($view->name == 'stanford_page_manage') {
+
+
+    // Add Field: Content: Accent color.
+    $options['id'] = 'field_s_banner_accent_color';
+    $options['table'] = 'field_data_field_s_banner_accent_color';
+    $options['field'] = 'field_s_banner_accent_color';
+    $options['type'] = 'taxonomy_term_reference_plain';
+
+    stanford_related_content_insert_item(
+      $view,
+      $display_id,
+      'field',
+      'field_data_field_s_banner_accent_color',
+      'field_s_banner_accent_color',
+      $options,
+      'name'
+    );
+
+    unset($options);
+
+    // Add Field: Content: Banner image.
+    $options['id'] = 'field_s_banner_image';
+    $options['table'] = 'field_data_field_s_banner_image';
+    $options['field'] = 'field_s_banner_image';
+    $options['click_sort_column'] = 'fid';
+    $options['settings'] = array(
+      'image_style' => 'thumbnail',
+      'image_link' => '',
+    );
+    stanford_related_content_insert_item(
+      $view,
+      $display_id,
+      'field',
+      'field_data_field_s_banner_image',
+      'field_s_banner_image',
+      $options,
+      'name'
+    );
+
+    if ($view->set_display('page')) {
+      unset($options);
+      $handler = $view->display_handler;
+
+      // Add Filter criterion: Content: Accent color (field_s_banner_accent_color).
+      $options = $handler->get_option('filters');
+      $options['field_s_banner_accent_color_tid']['id'] = 'field_s_banner_accent_color_tid';
+      $options['field_s_banner_accent_color_tid']['table'] = 'field_data_field_s_banner_accent_color';
+      $options['field_s_banner_accent_color_tid']['field'] = 'field_s_banner_accent_color_tid';
+      $options['field_s_banner_accent_color_tid']['value'] = '';
+      $options['field_s_banner_accent_color_tid']['exposed'] = TRUE;
+      $options['field_s_banner_accent_color_tid']['expose']['operator_id'] = 'field_s_banner_accent_color_tid_op';
+      $options['field_s_banner_accent_color_tid']['expose']['label'] = 'Accent color';
+      $options['field_s_banner_accent_color_tid']['expose']['operator'] = 'field_s_banner_accent_color_tid_op';
+      $options['field_s_banner_accent_color_tid']['expose']['identifier'] = 'field_s_banner_accent_color_tid';
+      $options['field_s_banner_accent_color_tid']['expose']['remember_roles'] = array(
+        2 => '2',
+        1 => 0,
+        12 => 0,
+        10 => 0,
+        8 => 0,
+        6 => 0,
+        20 => 0,
+        14 => 0,
+        16 => 0,
+        18 => 0,
+      );
+      $options['field_s_banner_accent_color_tid']['vocabulary'] = 'soe_accent_color';
+
+      $handler->set_option('filters', $options);
+    }
+  }
+}
+


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This adds banner image and accent color columns and color filter to manage content for Stanford Page.

# Needed By (Date)
- Abracadabra Sprint end

# Criticality
- Since the accent color must be removed when there is no bottom banner image, this will assist the client in identifying the accent color for each Stanford page.

# Steps to Test
- Switch to this branch
- Clear the cache
- Navigate to admin/manage/page
- Verify you see  "Accent color" filter, "Accent color" and "Banner Image" columns

# Affects
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
PR: https://stanfordits.atlassian.net/browse/SOE-2325
Dev: https://stanfordits.atlassian.net/browse/SOE-2222
## Related PRs

## More Information

## Folks to notify
@kbrownell


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)