### PR TITLE
7.x 2.x refine dm masthead

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -1947,34 +1947,7 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
 .page-magazine-all #header #logo img,
 .node-type-stanford-magazine-article #header #logo img {
   max-width: 90px; }
-  @media (max-width: 767px) {
-    /* line 15, ../scss/components/_soe_dm_brand_bar.scss */
-    .node-type-stanford-magazine-issue #header #logo img,
-    .page-taxonomy-term #header #logo img,
-    .node-type-stanford-magazine-issue #header #logo img,
-    .page-magazine #header #logo img,
-    .page-magazine-all #header #logo img,
-    .node-type-stanford-magazine-article #header #logo img {
-      max-width: 160px; } }
-  @media (max-width: 480px) {
-    /* line 15, ../scss/components/_soe_dm_brand_bar.scss */
-    .node-type-stanford-magazine-issue #header #logo img,
-    .page-taxonomy-term #header #logo img,
-    .node-type-stanford-magazine-issue #header #logo img,
-    .page-magazine #header #logo img,
-    .page-magazine-all #header #logo img,
-    .node-type-stanford-magazine-article #header #logo img {
-      max-width: 120px; } }
-  @media (max-width: 380px) {
-    /* line 15, ../scss/components/_soe_dm_brand_bar.scss */
-    .node-type-stanford-magazine-issue #header #logo img,
-    .page-taxonomy-term #header #logo img,
-    .node-type-stanford-magazine-issue #header #logo img,
-    .page-magazine #header #logo img,
-    .page-magazine-all #header #logo img,
-    .node-type-stanford-magazine-article #header #logo img {
-      max-width: 80px; } }
-/* line 30, ../scss/components/_soe_dm_brand_bar.scss */
+/* line 20, ../scss/components/_soe_dm_brand_bar.scss */
 .node-type-stanford-magazine-issue #header.header,
 .page-taxonomy-term #header.header,
 .node-type-stanford-magazine-issue #header.header,
@@ -1983,7 +1956,7 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
 .node-type-stanford-magazine-article #header.header {
   min-height: 45px;
   padding: 20px 0 0; }
-/* line 35, ../scss/components/_soe_dm_brand_bar.scss */
+/* line 25, ../scss/components/_soe_dm_brand_bar.scss */
 .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
 .page-taxonomy-term #header #site-title-first-line.site-title-uppercase,
 .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
@@ -1992,92 +1965,94 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
 .node-type-stanford-magazine-article #header #site-title-first-line.site-title-uppercase {
   font-size: 18px;
   margin-bottom: -3px; }
-  @media (max-width: 767px) {
-    /* line 35, ../scss/components/_soe_dm_brand_bar.scss */
-    .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
-    .page-taxonomy-term #header #site-title-first-line.site-title-uppercase,
-    .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
-    .page-magazine #header #site-title-first-line.site-title-uppercase,
-    .page-magazine-all #header #site-title-first-line.site-title-uppercase,
-    .node-type-stanford-magazine-article #header #site-title-first-line.site-title-uppercase {
-      font-size: 34px;
-      margin-bottom: -7px; } }
-  @media (max-width: 480px) {
-    /* line 35, ../scss/components/_soe_dm_brand_bar.scss */
-    .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
-    .page-taxonomy-term #header #site-title-first-line.site-title-uppercase,
-    .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
-    .page-magazine #header #site-title-first-line.site-title-uppercase,
-    .page-magazine-all #header #site-title-first-line.site-title-uppercase,
-    .node-type-stanford-magazine-article #header #site-title-first-line.site-title-uppercase {
-      font-size: 28px; } }
-  @media (max-width: 400px) {
-    /* line 35, ../scss/components/_soe_dm_brand_bar.scss */
-    .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
-    .page-taxonomy-term #header #site-title-first-line.site-title-uppercase,
-    .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
-    .page-magazine #header #site-title-first-line.site-title-uppercase,
-    .page-magazine-all #header #site-title-first-line.site-title-uppercase,
-    .node-type-stanford-magazine-article #header #site-title-first-line.site-title-uppercase {
-      font-size: 24px;
-      margin-bottom: -4px; } }
-  @media (max-width: 380px) {
-    /* line 35, ../scss/components/_soe_dm_brand_bar.scss */
-    .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
-    .page-taxonomy-term #header #site-title-first-line.site-title-uppercase,
-    .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
-    .page-magazine #header #site-title-first-line.site-title-uppercase,
-    .page-magazine-all #header #site-title-first-line.site-title-uppercase,
-    .node-type-stanford-magazine-article #header #site-title-first-line.site-title-uppercase {
-      font-size: 16px; } }
 
-/* line 9, ../scss/components/_soe_dm_navigation.scss */
+@media (max-width: 767px) {
+  /* line 16, ../scss/components/_soe_dm_navigation.scss */
+  .node-type-stanford-magazine-issue .navbar .btn.btn-navbar,
+  .page-taxonomy-term .navbar .btn.btn-navbar,
+  .node-type-stanford-magazine-issue .navbar .btn.btn-navbar,
+  .page-magazine .navbar .btn.btn-navbar,
+  .page-magazine-all .navbar .btn.btn-navbar,
+  .node-type-stanford-magazine-article .navbar .btn.btn-navbar {
+    background: #B1040E;
+    margin-top: -47px;
+    float: right; } }
+@media (max-width: 480px) {
+  /* line 16, ../scss/components/_soe_dm_navigation.scss */
+  .node-type-stanford-magazine-issue .navbar .btn.btn-navbar,
+  .page-taxonomy-term .navbar .btn.btn-navbar,
+  .node-type-stanford-magazine-issue .navbar .btn.btn-navbar,
+  .page-magazine .navbar .btn.btn-navbar,
+  .page-magazine-all .navbar .btn.btn-navbar,
+  .node-type-stanford-magazine-article .navbar .btn.btn-navbar {
+    margin-top: -47px; } }
+@media (max-width: 380px) {
+  /* line 16, ../scss/components/_soe_dm_navigation.scss */
+  .node-type-stanford-magazine-issue .navbar .btn.btn-navbar,
+  .page-taxonomy-term .navbar .btn.btn-navbar,
+  .node-type-stanford-magazine-issue .navbar .btn.btn-navbar,
+  .page-magazine .navbar .btn.btn-navbar,
+  .page-magazine-all .navbar .btn.btn-navbar,
+  .node-type-stanford-magazine-article .navbar .btn.btn-navbar {
+    margin-top: -47px; } }
+@media (max-width: 305px) {
+  /* line 16, ../scss/components/_soe_dm_navigation.scss */
+  .node-type-stanford-magazine-issue .navbar .btn.btn-navbar,
+  .page-taxonomy-term .navbar .btn.btn-navbar,
+  .node-type-stanford-magazine-issue .navbar .btn.btn-navbar,
+  .page-magazine .navbar .btn.btn-navbar,
+  .page-magazine-all .navbar .btn.btn-navbar,
+  .node-type-stanford-magazine-article .navbar .btn.btn-navbar {
+    float: left;
+    margin-top: 0; } }
+
+/* line 38, ../scss/components/_soe_dm_navigation.scss */
 #digital-magazine-menu {
   background: #00ECE9; }
   @media (max-width: 767px) {
-    /* line 12, ../scss/components/_soe_dm_navigation.scss */
+    /* line 41, ../scss/components/_soe_dm_navigation.scss */
     #digital-magazine-menu .container {
       width: auto;
       margin: 0 20px; } }
-  /* line 19, ../scss/components/_soe_dm_navigation.scss */
+  /* line 48, ../scss/components/_soe_dm_navigation.scss */
   #digital-magazine-menu .region-digital-magazine-menu {
     display: flex;
     justify-content: center; }
     @media (max-width: 979px) {
-      /* line 19, ../scss/components/_soe_dm_navigation.scss */
+      /* line 48, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-menu .region-digital-magazine-menu {
         flex-wrap: wrap; } }
     @media (max-width: 767px) {
-      /* line 19, ../scss/components/_soe_dm_navigation.scss */
+      /* line 48, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-menu .region-digital-magazine-menu {
         flex-wrap: nowrap; } }
     @media (min-width: 1200px) {
-      /* line 19, ../scss/components/_soe_dm_navigation.scss */
+      /* line 48, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-menu .region-digital-magazine-menu {
         margin-left: 74px; } }
-    /* line 32, ../scss/components/_soe_dm_navigation.scss */
+    /* line 61, ../scss/components/_soe_dm_navigation.scss */
     #digital-magazine-menu .region-digital-magazine-menu .block-menu-block {
       display: flex;
       align-items: center;
       justify-content: center;
       padding-top: 20px; }
       @media (max-width: 767px) {
-        /* line 32, ../scss/components/_soe_dm_navigation.scss */
+        /* line 61, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-menu .region-digital-magazine-menu .block-menu-block {
           display: block;
           width: 100%; } }
-      /* line 42, ../scss/components/_soe_dm_navigation.scss */
+      /* line 71, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2 {
         margin-bottom: 0;
         padding-bottom: 20px; }
         @media (max-width: 767px) {
-          /* line 42, ../scss/components/_soe_dm_navigation.scss */
+          /* line 71, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2 {
             float: left; } }
-        /* line 49, ../scss/components/_soe_dm_navigation.scss */
+        /* line 78, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2 a {
           text-decoration: none; }
-        /* line 53, ../scss/components/_soe_dm_navigation.scss */
+        /* line 82, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2:after {
           content: "|";
           font-size: 1.3125em;
@@ -2085,36 +2060,36 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
           padding: 0 30px;
           vertical-align: top; }
           @media (max-width: 767px) {
-            /* line 53, ../scss/components/_soe_dm_navigation.scss */
+            /* line 82, ../scss/components/_soe_dm_navigation.scss */
             #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2:after {
               content: none; } }
-      /* line 65, ../scss/components/_soe_dm_navigation.scss */
+      /* line 94, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul {
         margin-bottom: 0; }
-        /* line 68, ../scss/components/_soe_dm_navigation.scss */
+        /* line 97, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li {
           font-weight: 600;
           display: inline;
           float: left;
           list-style: none; }
-          /* line 74, ../scss/components/_soe_dm_navigation.scss */
+          /* line 103, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.collapsed, #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.expanded, #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.leaf {
             padding: 10px 20px 0 0; }
-          /* line 80, ../scss/components/_soe_dm_navigation.scss */
+          /* line 109, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li:first-child {
             margin-left: 0; }
             @media (max-width: 767px) {
-              /* line 80, ../scss/components/_soe_dm_navigation.scss */
+              /* line 109, ../scss/components/_soe_dm_navigation.scss */
               #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li:first-child {
                 float: right; } }
-          /* line 87, ../scss/components/_soe_dm_navigation.scss */
+          /* line 116, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li:last-child {
             margin-bottom: 0; }
           @media (max-width: 767px) {
-            /* line 91, ../scss/components/_soe_dm_navigation.scss */
+            /* line 120, ../scss/components/_soe_dm_navigation.scss */
             #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li:nth-child(2) {
               display: none; } }
-          /* line 98, ../scss/components/_soe_dm_navigation.scss */
+          /* line 127, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.first.leaf a:after {
             content: "";
             background-image: url("../img/soe_chevron_down_black.svg");
@@ -2124,59 +2099,59 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
             padding-left: 18px;
             margin-left: 12px; }
             @media (max-width: 767px) {
-              /* line 98, ../scss/components/_soe_dm_navigation.scss */
+              /* line 127, ../scss/components/_soe_dm_navigation.scss */
               #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.first.leaf a:after {
                 content: "\00a0 \00a0 \00a0 |"; } }
-          /* line 111, ../scss/components/_soe_dm_navigation.scss */
+          /* line 140, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.first.leaf a:hover:after {
             background-image: url("../img/soe_chevron_down_gray-orange.svg"); }
-          /* line 115, ../scss/components/_soe_dm_navigation.scss */
+          /* line 144, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.first.leaf a:focus:after {
             background-image: url("../img/soe_chevron_up_gray-orange.svg"); }
-          /* line 120, ../scss/components/_soe_dm_navigation.scss */
+          /* line 149, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a {
             color: #333333;
             padding-bottom: 20px;
             border-bottom: 2px solid transparent; }
-            /* line 125, ../scss/components/_soe_dm_navigation.scss */
+            /* line 154, ../scss/components/_soe_dm_navigation.scss */
             #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a:focus, #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a:hover {
               color: #686868;
               background-color: transparent;
               border-bottom-color: #686868; }
-            /* line 132, ../scss/components/_soe_dm_navigation.scss */
+            /* line 161, ../scss/components/_soe_dm_navigation.scss */
             #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a.active {
               color: #686868;
               border-bottom-color: #686868; }
 
-/* line 146, ../scss/components/_soe_dm_navigation.scss */
+/* line 175, ../scss/components/_soe_dm_navigation.scss */
 #digital-magazine-megamenu .container {
   background-color: #575757; }
-  /* line 150, ../scss/components/_soe_dm_navigation.scss */
+  /* line 179, ../scss/components/_soe_dm_navigation.scss */
   #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content {
     display: flex;
     flex-wrap: wrap;
     text-align: center; }
-    /* line 155, ../scss/components/_soe_dm_navigation.scss */
+    /* line 184, ../scss/components/_soe_dm_navigation.scss */
     #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row {
       width: calc(100% * (1/4) - 2%);
       margin-right: 2%; }
       @media (max-width: 767px) {
-        /* line 155, ../scss/components/_soe_dm_navigation.scss */
+        /* line 184, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row {
           width: calc(100% * (1/2) - 2%); } }
       @media (max-width: 480px) {
-        /* line 155, ../scss/components/_soe_dm_navigation.scss */
+        /* line 184, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row {
           width: 100%; } }
-      /* line 165, ../scss/components/_soe_dm_navigation.scss */
+      /* line 194, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row a {
         color: #FFFFFF;
         font-size: 1em; }
 
-/* line 176, ../scss/components/_soe_dm_navigation.scss */
+/* line 205, ../scss/components/_soe_dm_navigation.scss */
 #main-menu .navbar {
   margin-bottom: 0; }
-  /* line 181, ../scss/components/_soe_dm_navigation.scss */
+  /* line 210, ../scss/components/_soe_dm_navigation.scss */
   .node-type-stanford-magazine-issue #main-menu .navbar .nav > li > a, .page-taxonomy-term #main-menu .navbar .nav > li > a, .node-type-stanford-magazine-issue #main-menu .navbar .nav > li > a, .page-magazine #main-menu .navbar .nav > li > a,
   #main-menu .navbar .nav > li > a .page-magazine-all, .node-type-stanford-magazine-article #main-menu .navbar .nav > li > a {
     padding-bottom: 15px; }
@@ -3950,14 +3925,12 @@ html.js body > .hero-curtain-reveal {
       content: "Photo credit: \00a0"; }
 
 /* line 72, ../scss/components/_soe_people_spotlight.scss */
-.front .view-stanford-people-spotlight-fw-banner .spotlight-container, .front
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container, .front
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container {
+.front .view-stanford-people-spotlight-fw-banner .spotlight-container,
+.front .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container,
+.front .view-stanford-ppl-spot-fw-banner-quote .spotlight-container {
   background: #FFFFFF; }
 /* line 76, ../scss/components/_soe_people_spotlight.scss */
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
   display: flex;
   align-items: center;
   width: 50%;
@@ -3965,150 +3938,102 @@ html.js body > .hero-curtain-reveal {
   padding: 70px 0 0; }
   @media (max-width: 1900px) {
     /* line 76, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       width: 65%; } }
   @media (max-width: 1400px) {
     /* line 76, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       width: 85%; } }
   @media (max-width: 1200px) {
     /* line 76, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       width: 90%; } }
   @media (max-width: 767px) {
     /* line 76, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       display: block;
       text-align: center;
       width: 100%; } }
   /* line 97, ../scss/components/_soe_people_spotlight.scss */
-  .front .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .front
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .front
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+  .front .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .front .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .front .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
     padding: 70px 0; }
 /* line 102, ../scss/components/_soe_people_spotlight.scss */
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
   margin-right: 40px;
   flex-shrink: 0; }
   @media (max-width: 767px) {
     /* line 102, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
       margin-right: 0; } }
   /* line 109, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
     border-radius: 50%;
     border-width: 8px;
     border-style: solid; }
     @media (max-width: 767px) {
       /* line 109, ../scss/components/_soe_people_spotlight.scss */
-      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img,
-      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img,
-      .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
+      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
         max-width: 80%; } }
   /* line 118, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-orange img,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-orange img,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-orange img {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-orange img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-orange img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-orange img {
     border-color: #FFBD54; }
   /* line 122, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-turquoise img {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-turquoise img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-turquoise img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-turquoise img {
     border-color: #00ECE9; }
   /* line 126, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-pink img,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-pink img,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-pink img {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-pink img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-pink img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-pink img {
     border-color: #FF525C; }
 /* line 133, ../scss/components/_soe_people_spotlight.scss */
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a {
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a {
   text-decoration: underline;
   -webkit-text-decoration-skip: ink;
   text-decoration-skip: ink; }
   /* line 137, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:focus, .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:focus,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:focus,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:focus, .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:focus, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:focus, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover {
     -webkit-text-decoration-color: #333333;
     text-decoration-color: #333333; }
 /* line 143, ../scss/components/_soe_people_spotlight.scss */
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
   font-size: 2.4em;
   margin: 0 0 20px; }
   @media (max-width: 767px) {
     /* line 143, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
       margin-top: 15px; } }
 /* line 151, ../scss/components/_soe_people_spotlight.scss */
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a {
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a {
   -webkit-text-decoration-color: #FFBD54;
   text-decoration-color: #FFBD54; }
 /* line 155, ../scss/components/_soe_people_spotlight.scss */
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a {
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a {
   -webkit-text-decoration-color: #00ECE9;
   text-decoration-color: #00ECE9; }
 /* line 159, ../scss/components/_soe_people_spotlight.scss */
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a {
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a {
   -webkit-text-decoration-color: #FF525C;
   text-decoration-color: #FF525C; }
 /* line 164, ../scss/components/_soe_people_spotlight.scss */
 .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-degree p,
 .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-department p,
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-title p,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-title p, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
 .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-department p,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-title p,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
+.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-title p, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
 .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-department p,
 .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-title p {
   font-size: 1.2em;
   margin: 0; }
 /* line 171, ../scss/components/_soe_people_spotlight.scss */
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
   font-family: "Roboto Slab", serif;
   font-size: 1.4em;
   font-weight: 600;
   line-height: 1.3em;
   margin-top: 20px; }
   /* line 178, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote p:before,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote p:before,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote p:before {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote p:before, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote p:before, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote p:before {
     content: open-quote; }
   /* line 182, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote p:after,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote p:after,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote p:after {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote p:after, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote p:after, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote p:after {
     content: close-quote; }
 
 /* line 193, ../scss/components/_soe_people_spotlight.scss */

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -1947,7 +1947,16 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
 .page-magazine-all #header #logo img,
 .node-type-stanford-magazine-article #header #logo img {
   max-width: 90px; }
-/* line 20, ../scss/components/_soe_dm_brand_bar.scss */
+@media (max-width: 480px) {
+  /* line 19, ../scss/components/_soe_dm_brand_bar.scss */
+  .node-type-stanford-magazine-issue #header #logo.logo-mobile,
+  .page-taxonomy-term #header #logo.logo-mobile,
+  .node-type-stanford-magazine-issue #header #logo.logo-mobile,
+  .page-magazine #header #logo.logo-mobile,
+  .page-magazine-all #header #logo.logo-mobile,
+  .node-type-stanford-magazine-article #header #logo.logo-mobile {
+    padding: 0 5px 0 0; } }
+/* line 26, ../scss/components/_soe_dm_brand_bar.scss */
 .node-type-stanford-magazine-issue #header.header,
 .page-taxonomy-term #header.header,
 .node-type-stanford-magazine-issue #header.header,
@@ -1956,7 +1965,7 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
 .node-type-stanford-magazine-article #header.header {
   min-height: 45px;
   padding: 20px 0 0; }
-/* line 25, ../scss/components/_soe_dm_brand_bar.scss */
+/* line 31, ../scss/components/_soe_dm_brand_bar.scss */
 .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
 .page-taxonomy-term #header #site-title-first-line.site-title-uppercase,
 .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
@@ -1965,6 +1974,15 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
 .node-type-stanford-magazine-article #header #site-title-first-line.site-title-uppercase {
   font-size: 18px;
   margin-bottom: -3px; }
+@media (max-width: 480px) {
+  /* line 36, ../scss/components/_soe_dm_brand_bar.scss */
+  .node-type-stanford-magazine-issue #header #name-and-slogan.with-logo,
+  .page-taxonomy-term #header #name-and-slogan.with-logo,
+  .node-type-stanford-magazine-issue #header #name-and-slogan.with-logo,
+  .page-magazine #header #name-and-slogan.with-logo,
+  .page-magazine-all #header #name-and-slogan.with-logo,
+  .node-type-stanford-magazine-article #header #name-and-slogan.with-logo {
+    padding: 0 0 0 5px; } }
 
 @media (max-width: 767px) {
   /* line 16, ../scss/components/_soe_dm_navigation.scss */

--- a/scss/components/_soe_dm_brand_bar.scss
+++ b/scss/components/_soe_dm_brand_bar.scss
@@ -15,6 +15,12 @@
       img {
         max-width: 90px;
       }
+
+      &.logo-mobile {
+        @include breakpoint-max(x-small) {
+          padding: 0 5px 0 0;
+        }
+      }
     }
 
     &.header {
@@ -25,6 +31,12 @@
     #site-title-first-line.site-title-uppercase {
       font-size: 18px;
       margin-bottom: -3px;
+    }
+
+    #name-and-slogan.with-logo {
+      @include breakpoint-max(x-small) {
+        padding: 0 0 0 5px;
+      }
     }
   }
 }

--- a/scss/components/_soe_dm_brand_bar.scss
+++ b/scss/components/_soe_dm_brand_bar.scss
@@ -13,17 +13,7 @@
   #header {
     #logo {
       img {
-
         max-width: 90px;
-        @include breakpoint-max(small) {
-          max-width: 160px;
-        }
-        @media (max-width: 480px) {
-          max-width: 120px;
-        }
-        @media (max-width: 380px) {
-          max-width: 80px;
-        }
       }
     }
 
@@ -35,20 +25,6 @@
     #site-title-first-line.site-title-uppercase {
       font-size: 18px;
       margin-bottom: -3px;
-      @include breakpoint-max(small) {
-        font-size: 34px;
-        margin-bottom: -7px;
-      }
-      @include breakpoint-max(x-small) {
-        font-size: 28px;
-      }
-      @media (max-width: 400px) {
-        font-size: 24px;
-        margin-bottom: -4px;
-      }
-      @media (max-width: 380px) {
-        font-size: 16px;
-      }
     }
   }
 }

--- a/scss/components/_soe_dm_navigation.scss
+++ b/scss/components/_soe_dm_navigation.scss
@@ -6,6 +6,35 @@
 
 // PRIMARY NAVIGATION
 
+.node-type-stanford-magazine-issue,
+.page-taxonomy-term,
+.node-type-stanford-magazine-issue,
+.page-magazine,
+.page-magazine-all,
+.node-type-stanford-magazine-article {
+  .navbar {
+    .btn.btn-navbar {
+      @include breakpoint-max(small) {
+        background: $brand-bright;
+        margin-top: -47px;
+        float: right;
+      }
+      @include breakpoint-max(x-small) {
+        margin-top: -47px;
+      }
+      @media (max-width: 380px) {
+        margin-top: -47px;
+      }
+      @media (max-width: 305px) {
+        float: left;
+        margin-top: 0;
+      }
+    }
+  }
+}
+
+// DIGITAL MAGAZINE NAVIGATION
+
 #digital-magazine-menu {
   background: $turquoise;
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary

- Fixes the masthead jump back to big size. Now it stays petit.
- Brings hamburger menu into alignment with masthead.

# Needed By (Date)
- Sprint end

# Criticality
- Fixes broken stuff

# Steps to Test
- Switch to this branch
- May need to revert feature
- Navigate to /magazine, /magazine/issue, and any article page
- Verify you see a small masthead and the hamburger menu in alignment.

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-2281
## Related PRs

## More Information
See screenshots from ticket:

https://stanfordits.atlassian.net/secure/attachment/37257/Screen%20Shot%202017-10-12%20at%2017.13.12.png
https://stanfordits.atlassian.net/secure/attachment/37258/Screen%20Shot%202017-10-12%20at%2017.13.40.png

## Folks to notify
@kbrownell 


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)