### PR TITLE
SOE-2237 added School News label to homepage view

### DIFF
--- a/modules/stanford_soe_helper_news/stanford_soe_helper_news.views_default.inc
+++ b/modules/stanford_soe_helper_news/stanford_soe_helper_news.views_default.inc
@@ -132,7 +132,7 @@ function stanford_soe_helper_news_views_default_views() {
       <div class="feat-news-img">[field_s_image_info]</div>
   </a>
       <div class="feat-news-content-container">
-           <div class="feat-news-date">School News - [field_s_news_date]</div>
+           <div class="feat-news-date">School News – [field_s_news_date]</div>
            <div class="feat-news-title"><h2>[title]</h2></div>
            <div class="feat-news-teaser">[field_s_news_teaser]</div>
            <div class="edit-link">[edit_node]</div>

--- a/modules/stanford_soe_helper_news/stanford_soe_helper_news.views_default.inc
+++ b/modules/stanford_soe_helper_news/stanford_soe_helper_news.views_default.inc
@@ -132,7 +132,7 @@ function stanford_soe_helper_news_views_default_views() {
       <div class="feat-news-img">[field_s_image_info]</div>
   </a>
       <div class="feat-news-content-container">
-           <div class="feat-news-date">[field_s_news_date]</div>
+           <div class="feat-news-date">School News - [field_s_news_date]</div>
            <div class="feat-news-title"><h2>[title]</h2></div>
            <div class="feat-news-teaser">[field_s_news_teaser]</div>
            <div class="edit-link">[edit_node]</div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added "School News" label to homepage Featured News view

# Needed By (Date)
- End of sprint (10/25)

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. Revert `stanford_soe_helper_news`
3. Verify that the homepage Featured News block looks like mockup on ticket (InVision) or on related Google Doc (see links below)

# Affected Projects or Products
- stanford_soe_helper
- SOE

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-2237
- https://projects.invisionapp.com/d/main#/console/10423578/254415347/inspect
- https://docs.google.com/document/d/1LCuqHA9ZTsnGlPDHz0hGI1A5GgJu6VMQrxMfJZNyUn8/edit#heading=h.ukeg00a6zyb6

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)