### PR TITLE
SOE-2492: Remove image style from og:image

### DIFF
--- a/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
+++ b/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
@@ -380,7 +380,7 @@ function stanford_soe_helper_magazine_preprocess_page(&$variables) {
         '#tag' => 'meta',
         '#attributes' => array(
           'property' => 'og:image',
-          'content' => $GLOBALS['base_url'] . '/sites/default/files/styles/full_width_banner_tall/public/' . $variables['node']->field_s_mag_article_image[LANGUAGE_NONE][0]['filename'],
+          'content' => $GLOBALS['base_url'] . '/sites/default/files/' . $variables['node']->field_s_mag_article_image[LANGUAGE_NONE][0]['filename'],
         )
       ),
       'facebook_image_width' => array(


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Tanja noticed that Facebook was not finding a default image for magazine articles.  It appears from testing, that when pointing Facebook towards a cached image style, it was indeed not able to find an image file.  Pointing Facebook to the original image, not a cached version, appears to reliably fix this issue.

# Needed By (12/6)

# Urgency
- It sounds like this is a blocker for Tanja's work.

# Steps to Test

1. This branch is checked out on dev and nobots have been disabled, so that Facebook can find and access Open Graph related metadata on the site.
2. Find a magazine article at https://sites.stanford.edu/jse-soe-dev/magazine.
3. On the magazine article page, click the "f" facebook share icon.  *But do not SHARE the dev page on your facebook account.*  Simply check that the image and article title, description load in the preview.  Please include a screenshot of this page in the comments below.  It should look like this.
![screen shot 2017-12-06 at 11 37 05 am](https://user-images.githubusercontent.com/4072139/33681592-e0ddd6a0-da79-11e7-9ad1-1852b6afef2a.png)
4. Find a second article to test at https://sites.stanford.edu/jse-soe-dev/magazine.
5. Visit: https://developers.facebook.com/tools/debug/sharing and enter the magazine article URL you chose to test.
6. Click Debug and then click "Fetch new information" or "Scrape again" (depending on whether this particular page has been tested before).  If clicking "Scrape again", continue clicking it like 5-10 times until the "Time Scraped" date finally updates to a few seconds ago.
7. Even then, wait a few more seconds.  Then, scroll down and see whether the image, article title and description loaded in the preview.  Please include a screenshot of this in the comments below.  It should look something like this.
![screen shot 2017-12-06 at 11 38 16 am](https://user-images.githubusercontent.com/4072139/33681642-036d8e68-da7a-11e7-83b3-f0e3621ff06c.png)


# Affected Projects or Products
- SOE's newsletter and site.

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-2492
- @boznik 