### PR TITLE
SOE-2510: New image style for facebook sharing

### DIFF
--- a/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
+++ b/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
@@ -347,6 +347,10 @@ function stanford_soe_helper_magazine_preprocess_views_view(&$vars) {
 
 function stanford_soe_helper_magazine_preprocess_page(&$variables) {
   if (isset($variables['node']) && $variables['node']->type == 'stanford_magazine_article') {
+    $facebook_image = array(
+      'style_name' => 'facebook_share_image',
+      'path' => $GLOBALS['base_url'] . '/sites/default/files/styles/facebook_share_image/public/' . $variables['node']->field_s_mag_article_image[LANGUAGE_NONE][0]['filename'], 
+    );
     $html_head = array(
       'twitter_card' => array(
         '#tag' => 'meta',
@@ -380,21 +384,21 @@ function stanford_soe_helper_magazine_preprocess_page(&$variables) {
         '#tag' => 'meta',
         '#attributes' => array(
           'property' => 'og:image',
-          'content' => $GLOBALS['base_url'] . '/sites/default/files/styles/full_width_banner_tall/public/' . $variables['node']->field_s_mag_article_image[LANGUAGE_NONE][0]['filename'],
+          'content' => $GLOBALS['base_url'] . '/sites/default/files/styles/facebook_share_image/public/' . $variables['node']->field_s_mag_article_image[LANGUAGE_NONE][0]['filename'],
         )
       ),
       'facebook_image_width' => array(
         '#tag' => 'meta',
         '#attributes' => array(
           'property' => 'og:image:width',
-          'content' => '1170',
+          'content' => '1200',
         )
       ),
       'facebook_image_height' => array(
         '#tag' => 'meta',
         '#attributes' => array(
           'property' => 'og:image:height',
-          'content' => '550',
+          'content' => '630',
         )
       ),
     );

--- a/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
+++ b/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
@@ -347,10 +347,6 @@ function stanford_soe_helper_magazine_preprocess_views_view(&$vars) {
 
 function stanford_soe_helper_magazine_preprocess_page(&$variables) {
   if (isset($variables['node']) && $variables['node']->type == 'stanford_magazine_article') {
-    $facebook_image = array(
-      'style_name' => 'facebook_share_image',
-      'path' => $GLOBALS['base_url'] . '/sites/default/files/styles/facebook_share_image/public/' . $variables['node']->field_s_mag_article_image[LANGUAGE_NONE][0]['filename'], 
-    );
     $html_head = array(
       'twitter_card' => array(
         '#tag' => 'meta',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Facebook was not able to reliably find and cache magazine article images for sharing on their platform.  It appears that either the images were too large or Facebook preferred they be the 1200x630 recommended size for pre-caching.

# Needed By (12/18)

# Urgency
- SOE has an email newsletter they would like to send Tues. 12/19 around 9am.  They would like this on their live site before then.

# Steps to Test

1. This branch and it's corresponding branch on stanford_image_styles is checked out on SOE's dev site: https://sites.stanford.edu/jse-soe-dev.
2. Visit several of the following magazine articles (which will be featured in their upcoming email newsletter):
https://sites.stanford.edu/jse-soe-dev/magazine/article/researchers-look-fruit-fly-help-understand-human-brain
https://sites.stanford.edu/jse-soe-dev/magazine/article/jenny-suckale-better-plan-b-managing-disasters
https://sites.stanford.edu/jse-soe-dev/magazine/article/can-algorithm-diagnose-pneumonia-better-radiologist
https://sites.stanford.edu/jse-soe-dev/magazine/article/simulating-human-movement-optimize-physical-performance
https://sites.stanford.edu/jse-soe-dev/magazine/article/can-artificial-intelligence-infer-neighborhood-politics-its-cars
3. For each page, click on the "f" Facebook share.  Do you see the article title, description, and featured image on the Facebook share preview page?  If no image appears immediately, try refreshing the page, but you should only have to refresh once!

![screen shot 2017-12-15 at 3 39 46 pm](https://user-images.githubusercontent.com/4072139/34064494-3bba79bc-e1ae-11e7-8f2d-c17ee47fb585.png)


# Affected Projects or Products
- SOE's upcoming email newsletter
- This adds a new dependency on the soon-to-be-released 7.x-4.3-alpha1 tag of stanford_image_styles, open PR: https://github.com/SU-SWS/stanford_image_styles/pull/43.  I'm not seeing stanford_image_styles as a dependency for stanford_soe_helper, should it be?
- This will go into a 7.x-2.0-beta2 release of this module.

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-2510
- PR: https://github.com/SU-SWS/stanford_image_styles/pull/43
- @boznik @sherakama @cjwest 