### PR TITLE
SOE-2643: first round, not quite working

### DIFF
--- a/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.install
+++ b/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.install
@@ -243,3 +243,51 @@ function stanford_soe_helper_magazine_update_7201() {
     }
   }
 }
+
+/**
+ * Implements hook_update_N().
+ */
+function stanford_soe_helper_magazine_update_7202(&$sandbox) {
+  $title = 'Print';
+  $url = '/print/[current-page:url:path]';
+
+  $query = db_query("SELECT nid, vid from {node} WHERE type = :type",
+    array(':type' => 'stanford_magazine_article'));
+
+  $records = $query->fetchAll();
+  foreach ($records as $record) {
+    $query = db_merge('field_data_field_s_mag_article_print')
+      ->key(array(
+        'entity_id' => $record->nid,
+      ))
+      ->fields(array(
+        'entity_type' => 'node',
+        'field_s_mag_article_print_url' => $url,
+        'field_s_mag_article_print_title' => $title,
+        'field_s_mag_article_print_attributes' => serialize(array()),
+        'deleted' => 0,
+        'delta' => 0,
+        'bundle' => 'stanford_magazine_article',
+        'revision_id' => $record->vid,
+        'language' => 'und',
+      ))
+      ->execute();
+
+    $query = db_merge('field_revision_field_s_mag_article_print')
+      ->key(array(
+        'entity_id' => $record->nid,
+      ))
+      ->fields(array(
+        'entity_type' => 'node',
+        'field_s_mag_article_print_url' => $url,
+        'field_s_mag_article_print_title' => $title,
+        'field_s_mag_article_print_attributes' => serialize(array()),
+        'deleted' => 0,
+        'delta' => 0,
+        'bundle' => 'stanford_magazine_article',
+        'revision_id' => $record->vid,
+        'language' => 'und',
+      ))
+      ->execute();
+  }
+}

--- a/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
+++ b/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
@@ -346,7 +346,9 @@ function stanford_soe_helper_magazine_preprocess_views_view(&$vars) {
 
 
 function stanford_soe_helper_magazine_preprocess_page(&$variables) {
+
   if (isset($variables['node']) && $variables['node']->type == 'stanford_magazine_article') {
+    update_print_fields();
     $html_head = array(
       'twitter_card' => array(
         '#tag' => 'meta',
@@ -403,5 +405,34 @@ function stanford_soe_helper_magazine_preprocess_page(&$variables) {
     }
     drupal_add_js('https://platform.twitter.com/widgets.js');
     drupal_add_js(drupal_get_path('module', 'stanford_soe_helper_magazine') . '/js/stanford_social_widgets.js');
+  }
+}
+
+function update_print_fields() {
+  $title = 'Print';
+  $url = '/print/[current-page:url:path]';
+
+  $query = db_query("SELECT nid, vid from {node} WHERE type = :type",
+    array(':type' => 'stanford_magazine_article'));
+
+  $records = $query->fetchAll();
+  foreach ($records as $record) {
+
+    db_merge('field_data_field_s_mag_article_print')
+      ->key(array(
+        'entity_type' => 'node',
+        'entity_id' => $record->nid,
+        'deleted' => '0',
+        'language' => 'und',
+        'delta' => '0',
+        'bundle' => 'stanford_magazine_article',
+        'revision_id' => $record->vid,
+      ))
+      ->fields(array(
+        'field_s_mag_article_print_url' => $url,
+        'field_s_mag_article_print_title' => $title,
+        'field_s_mag_article_print_attributes' => array(),
+      ))
+      ->execute();
   }
 }

--- a/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
+++ b/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
@@ -411,28 +411,36 @@ function stanford_soe_helper_magazine_preprocess_page(&$variables) {
 function update_print_fields() {
   $title = 'Print';
   $url = '/print/[current-page:url:path]';
+  $attributes = array();
 
   $query = db_query("SELECT nid, vid from {node} WHERE type = :type",
     array(':type' => 'stanford_magazine_article'));
 
   $records = $query->fetchAll();
+  $count = 0;
   foreach ($records as $record) {
 
-    db_merge('field_data_field_s_mag_article_print')
-      ->key(array(
+    if ($count == 3) {
+      $query = db_merge('field_data_field_s_mag_article_print')
+        ->key(array(
+          'entity_id' => $record->nid,
+        ))
+        ->fields(array(
         'entity_type' => 'node',
-        'entity_id' => $record->nid,
-        'deleted' => '0',
-        'language' => 'und',
-        'delta' => '0',
-        'bundle' => 'stanford_magazine_article',
-        'revision_id' => $record->vid,
-      ))
-      ->fields(array(
         'field_s_mag_article_print_url' => $url,
         'field_s_mag_article_print_title' => $title,
-        'field_s_mag_article_print_attributes' => array(),
-      ))
-      ->execute();
+        'field_s_mag_article_print_attributes' => $attributes,
+        'deleted' => 0,
+        'delta' => 0,
+        'bundle' => 'stanford_magazine_article',
+        'revision_id' => $record->vid,
+        ))
+        ->execute();
+      dpm($query);
+      dpm($count);
+      dpm($record);
+
+    }
+    $count++;
   }
 }

--- a/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
+++ b/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
@@ -346,9 +346,7 @@ function stanford_soe_helper_magazine_preprocess_views_view(&$vars) {
 
 
 function stanford_soe_helper_magazine_preprocess_page(&$variables) {
-
   if (isset($variables['node']) && $variables['node']->type == 'stanford_magazine_article') {
-    update_print_fields();
     $html_head = array(
       'twitter_card' => array(
         '#tag' => 'meta',
@@ -408,39 +406,3 @@ function stanford_soe_helper_magazine_preprocess_page(&$variables) {
   }
 }
 
-function update_print_fields() {
-  $title = 'Print';
-  $url = '/print/[current-page:url:path]';
-  $attributes = array();
-
-  $query = db_query("SELECT nid, vid from {node} WHERE type = :type",
-    array(':type' => 'stanford_magazine_article'));
-
-  $records = $query->fetchAll();
-  $count = 0;
-  foreach ($records as $record) {
-
-    if ($count == 3) {
-      $query = db_merge('field_data_field_s_mag_article_print')
-        ->key(array(
-          'entity_id' => $record->nid,
-        ))
-        ->fields(array(
-        'entity_type' => 'node',
-        'field_s_mag_article_print_url' => $url,
-        'field_s_mag_article_print_title' => $title,
-        'field_s_mag_article_print_attributes' => $attributes,
-        'deleted' => 0,
-        'delta' => 0,
-        'bundle' => 'stanford_magazine_article',
-        'revision_id' => $record->vid,
-        ))
-        ->execute();
-      dpm($query);
-      dpm($count);
-      dpm($record);
-
-    }
-    $count++;
-  }
-}

--- a/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
+++ b/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.module
@@ -405,4 +405,3 @@ function stanford_soe_helper_magazine_preprocess_page(&$variables) {
     drupal_add_js(drupal_get_path('module', 'stanford_soe_helper_magazine') . '/js/stanford_social_widgets.js');
   }
 }
-


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The print functionality was added after much of the content was imported. Rather than edit 600+ nodes to add the print information, we created this update hook. This hook updates both the field_revision_field_s_mag_article_print and field_data_field_s_mag_article_print tables in the database.

# Needed By (Date)
- Sprint end

# Criticality
- Client is eagerly awaiting this.

# Steps to Test
Verify you have a node without print settings ~ one of the earlier ones will work, say node/7610

![screen shot 2018-02-23 at 11 08 11](https://user-images.githubusercontent.com/284440/36612007-303ed9bc-188a-11e8-82f5-9ec27ea625ae.png)


Switch to this branch
`git fetch`
`git checkout 7.x-2.x-update-print-fields`
`drush cc all`

Run database updates
`drush updb`

you should see:
```
 Stanford_soe_helper_magazine  7202  Implements hook_update_N().
Do you wish to run all pending updates? (y/n): y
Performed update: stanford_soe_helper_magazine_update_7202                        [ok]
'all' cache was cleared.                                               
Finished performing updates.
```
Verify your testing node will render a print page

![screen shot 2018-02-23 at 11 07 05](https://user-images.githubusercontent.com/284440/36611875-ba7dbedc-1889-11e8-88fa-13d1d136adc2.png)


# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)

https://stanfordits.atlassian.net/browse/SOE-2643

## Related PRs

## More Information
Thank you, @boznik, for your help on this!

## Folks to notify
@andydunmire 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)