### PR TITLE
SOE-2785: turning off disable sql rewrite

### DIFF
--- a/modules/stanford_soe_helper_collection_views/stanford_soe_helper_collection_views.views_default.inc
+++ b/modules/stanford_soe_helper_collection_views/stanford_soe_helper_collection_views.views_default.inc
@@ -27,7 +27,7 @@ function stanford_soe_helper_collection_views_views_default_views() {
   $handler->display->display_options['access']['type'] = 'perm';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
-  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = TRUE;
+  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = FALSE;
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'some';
   $handler->display->display_options['pager']['options']['items_per_page'] = '1';
@@ -641,7 +641,7 @@ function stanford_soe_helper_collection_views_views_default_views() {
   $handler->display->display_options['cache']['output_lifespan'] = '3600';
   $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
   $handler->display->display_options['query']['type'] = 'views_query';
-  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = TRUE;
+  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = FALSE;
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'some';
   $handler->display->display_options['pager']['options']['items_per_page'] = '3';

--- a/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.views_default.inc
+++ b/modules/stanford_soe_helper_magazine/stanford_soe_helper_magazine.views_default.inc
@@ -31,7 +31,7 @@ function stanford_soe_helper_magazine_views_default_views() {
   $handler->display->display_options['cache']['output_lifespan'] = '3600';
   $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
   $handler->display->display_options['query']['type'] = 'views_query';
-  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = TRUE;
+  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = FALSE;
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'some';
   $handler->display->display_options['pager']['options']['items_per_page'] = '1';
@@ -410,7 +410,7 @@ function stanford_soe_helper_magazine_views_default_views() {
   $handler->display->display_options['cache']['output_lifespan'] = '3600';
   $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
   $handler->display->display_options['query']['type'] = 'views_query';
-  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = TRUE;
+  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = FALSE;
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'some';
   $handler->display->display_options['pager']['options']['items_per_page'] = '1';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Turn off "Disable SQL Rewrite" in views


# Needed By (04/25/2018)

# Criticality
- Client is eagerly awaiting this.

# Steps to Test
- After core patch, we must change $handler->display->display_options['query']['options']['disable_sql_rewrite'] = TRUE; to $handler->display->display_options['query']['options']['disable_sql_rewrite'] = FALSE; 

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-2804

## More Information

## Folks to notify
@minorwm
