### PR TITLE
HOTFIX for font-size after stanford_framework update

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -592,9 +592,9 @@ p.summary.drop-cap:first-letter {
         font-size: 16px;
         margin-bottom: -4px; } }
 
-/* line 97, ../scss/components/_soe_brand_bar.scss */
-#site-title-first-line.site-title-uppercase,
-#site-title-first-line.site-title-uppercase a {
+/* line 98, ../scss/components/_soe_brand_bar.scss */
+.dm-global-header #site-title-first-line.site-title-uppercase,
+.dm-global-header #site-title-first-line.site-title-uppercase a {
   font-size: 18px; }
 
 /* line 8, ../scss/components/_soe_footer.scss */

--- a/scss/components/_soe_brand_bar.scss
+++ b/scss/components/_soe_brand_bar.scss
@@ -94,7 +94,9 @@
   }
 }
 
-#site-title-first-line.site-title-uppercase,
-#site-title-first-line.site-title-uppercase a {
-    font-size: 18px;
+.dm-global-header {
+  #site-title-first-line.site-title-uppercase,
+  #site-title-first-line.site-title-uppercase a {
+      font-size: 18px;
+  }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- HOTFIX for font-size after stanford_framework update

# Needed By (Date)
- Sprint end

# Criticality
- Fixes broken stuff


# Steps to Test

- Make sure the header font-size logo looks right

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)

## Related PRs
https://github.com/SU-SOE/stanford_soe_helper/tree/hotfix-font-size-header

## More Information

You might want to just pull this into your SASS.

## Folks to notify

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)