### PR TITLE
Collections Injector file 37 into SCSS - merge

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -2591,21 +2591,24 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
           margin: 10px auto 0; } }
 /* line 356, ../scss/components/_soe_dm_collection.scss */
 .node-type-stanford-collection .view-display-id-collection_group_block_1 .views-row {
-  margin-bottom: 0;
-  margin-top: 40px; }
-/* line 361, ../scss/components/_soe_dm_collection.scss */
+  margin: 80px 0; }
+  @media (max-width: 480px) {
+    /* line 356, ../scss/components/_soe_dm_collection.scss */
+    .node-type-stanford-collection .view-display-id-collection_group_block_1 .views-row {
+      margin: 40px 0; } }
+/* line 364, ../scss/components/_soe_dm_collection.scss */
 .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-img {
   width: 45%;
   float: left; }
   @media (max-width: 1200px) {
-    /* line 361, ../scss/components/_soe_dm_collection.scss */
+    /* line 364, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-img {
       width: 41%; } }
   @media (max-width: 979px) {
-    /* line 361, ../scss/components/_soe_dm_collection.scss */
+    /* line 364, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-img {
       width: 100%; } }
-/* line 374, ../scss/components/_soe_dm_collection.scss */
+/* line 377, ../scss/components/_soe_dm_collection.scss */
 .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-container {
   background: #FFFFFF;
   float: left;
@@ -2614,7 +2617,7 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 383, ../scss/components/_soe_dm_collection.scss */
+  /* line 386, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-container .mag-article-content-container {
     float: left;
     width: 49%;
@@ -2622,18 +2625,18 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     -moz-box-shadow: none;
     box-shadow: none; }
     @media (max-width: 1200px) {
-      /* line 383, ../scss/components/_soe_dm_collection.scss */
+      /* line 386, ../scss/components/_soe_dm_collection.scss */
       .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-container .mag-article-content-container {
         min-height: auto;
         width: 52%; }
-        /* line 394, ../scss/components/_soe_dm_collection.scss */
+        /* line 397, ../scss/components/_soe_dm_collection.scss */
         .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-container .mag-article-content-container .mag-article-topics {
           margin: 20px 0 0 !important; } }
     @media (max-width: 979px) {
-      /* line 383, ../scss/components/_soe_dm_collection.scss */
+      /* line 386, ../scss/components/_soe_dm_collection.scss */
       .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-container .mag-article-content-container {
         width: auto; } }
-/* line 405, ../scss/components/_soe_dm_collection.scss */
+/* line 408, ../scss/components/_soe_dm_collection.scss */
 .node-type-stanford-collection .view-display-id-collection_group_block_1 .edit-link {
   float: left;
   margin-bottom: 20px;

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -2592,7 +2592,7 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
 /* line 356, ../scss/components/_soe_dm_collection.scss */
 .node-type-stanford-collection .view-display-id-collection_group_block_1 .views-row {
   margin: 80px 0; }
-  @media (max-width: 480px) {
+  @media (max-width: 580px) {
     /* line 356, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-collection .view-display-id-collection_group_block_1 .views-row {
       margin: 40px 0; } }

--- a/scss/components/_soe_dm_collection.scss
+++ b/scss/components/_soe_dm_collection.scss
@@ -354,8 +354,11 @@
 
   .view-display-id-collection_group_block_1 {
     .views-row {
-      margin-bottom: 0;
-      margin-top: 40px;
+      margin: 80px 0;
+
+      @include breakpoint-max(x-small) {
+        margin: 40px 0;
+      }
     }
 
     .mag-article-img {

--- a/scss/components/_soe_dm_collection.scss
+++ b/scss/components/_soe_dm_collection.scss
@@ -356,7 +356,7 @@
     .views-row {
       margin: 80px 0;
 
-      @include breakpoint-max(x-small) {
+      @include breakpoint-max(smaller) {
         margin: 40px 0;
       }
     }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
This adds the Collections Injector file 37 into SCSS.

# Needed By (Date)
- Sprint end

# Criticality
- Collections Injector file 37 into SCSS


# Steps to Test
- Switch to this branch  -  7.x-2.x-SOE-2919-merge (https://github.com/SU-SOE/stanford_soe_helper/tree/7.x-2.x-SOE-2919-merge)
- delete this injector: `admin/config/development/css-injector/edit/37`
- `drush cc all`
- go to: `magazine/future-everything` and make sure the css is showing.

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-2919

## Related PRs

## More Information

## Folks to notify
@cjwest and @boznik 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)