### PR TITLE
2-Column Text Style from Injector 44 to SCSS - merged

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -269,40 +269,44 @@ th {
   .main p {
     margin: 0 0 1.5em; }
     /* line 274, ../scss/components/_soe_global.scss */
+    .main p.columns {
+      column-count: 1;
+      column-gap: 0; }
+    /* line 278, ../scss/components/_soe_global.scss */
     .main p a {
       text-decoration: underline; }
-      /* line 277, ../scss/components/_soe_global.scss */
+      /* line 281, ../scss/components/_soe_global.scss */
       .main p a.btn {
         text-decoration: none; }
-  /* line 283, ../scss/components/_soe_global.scss */
+  /* line 287, ../scss/components/_soe_global.scss */
   .main .block {
     margin-bottom: 50px; }
 
 @media (max-width: 767px) {
-  /* line 288, ../scss/components/_soe_global.scss */
+  /* line 292, ../scss/components/_soe_global.scss */
   .container {
     margin-bottom: 10px; }
-    /* line 292, ../scss/components/_soe_global.scss */
+    /* line 296, ../scss/components/_soe_global.scss */
     #fullwidth-bottom .container {
       margin-bottom: 0; } }
 
 @media (min-width: 1200px) {
-  /* line 298, ../scss/components/_soe_global.scss */
+  /* line 302, ../scss/components/_soe_global.scss */
   #content.span9 {
     width: 740px;
     margin-left: 80px; } }
 
 /*** BODY - MORE SPACE FROM LAST CHILD TO TOP OF BLOCKS AFTER WYSIWYG ***/
-/* line 306, ../scss/components/_soe_global.scss */
+/* line 310, ../scss/components/_soe_global.scss */
 .content-body p:last-child {
   margin-bottom: 2.5em; }
 
-/* line 310, ../scss/components/_soe_global.scss */
+/* line 314, ../scss/components/_soe_global.scss */
 .region-sidebar-second {
   margin-top: 34px; }
 
 /*** Full width region ***/
-/* line 316, ../scss/components/_soe_global.scss */
+/* line 320, ../scss/components/_soe_global.scss */
 .region-fullwidth-top #block-ds-extras-featured-image img {
   width: 100%; }
 
@@ -410,12 +414,12 @@ p.columns {
   font-size: 1.4em;
   line-height: 1.6em;
   font-weight: bold;
-  -webkit-column-count: 2;
-  -moz-column-count: 2;
-  column-count: 2;
-  -webkit-column-gap: 80px;
-  -moz-column-gap: 80px;
-  column-gap: 80px; }
+  -webkit-column-count: 1;
+  -moz-column-count: 1;
+  column-count: 1;
+  -webkit-column-gap: 0;
+  -moz-column-gap: 0;
+  column-gap: 0; }
   @media (max-width: 767px) {
     /* line 120, ../scss/components/_soe_wysiwyg.scss */
     p.columns {
@@ -430,8 +434,14 @@ p.columns {
     -webkit-column-count: 1;
     -moz-column-count: 1;
     column-count: 1; }
+    /* line 136, ../scss/components/_soe_wysiwyg.scss */
+    .group-p-ws-style p.columns p.columns {
+      font-size: 1.2em;
+      line-height: 1.6em;
+      column-count: 1;
+      padding: 0 50px; }
 
-/* line 138, ../scss/components/_soe_wysiwyg.scss */
+/* line 145, ../scss/components/_soe_wysiwyg.scss */
 p.related-link {
   background: #FFFFFF;
   line-height: 1.3em;
@@ -439,37 +449,37 @@ p.related-link {
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 144, ../scss/components/_soe_wysiwyg.scss */
+  /* line 151, ../scss/components/_soe_wysiwyg.scss */
   p.related-link a {
     text-decoration: none; }
-    /* line 147, ../scss/components/_soe_wysiwyg.scss */
+    /* line 154, ../scss/components/_soe_wysiwyg.scss */
     p.related-link a:focus, p.related-link a:hover {
       text-decoration: underline; }
-  /* line 153, ../scss/components/_soe_wysiwyg.scss */
+  /* line 160, ../scss/components/_soe_wysiwyg.scss */
   p.related-link:before {
     content: "Related \00a0 | \00a0";
     font-weight: 600; }
 
-/* line 160, ../scss/components/_soe_wysiwyg.scss */
+/* line 167, ../scss/components/_soe_wysiwyg.scss */
 p.summary.drop-cap:first-letter {
   padding: 25px 10px 0 0;
   font-size: 2.875em;
   font-weight: 600;
   float: left; }
   @media (max-width: 1200px) {
-    /* line 160, ../scss/components/_soe_wysiwyg.scss */
+    /* line 167, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 21px 10px 0 0; } }
   @media (max-width: 979px) {
-    /* line 160, ../scss/components/_soe_wysiwyg.scss */
+    /* line 167, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 16px 10px 0 0; } }
   @media (max-width: 480px) {
-    /* line 160, ../scss/components/_soe_wysiwyg.scss */
+    /* line 167, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 15px 10px 0 0; } }
 
-/* line 178, ../scss/components/_soe_wysiwyg.scss */
+/* line 185, ../scss/components/_soe_wysiwyg.scss */
 .caption {
   color: #606060;
   font-weight: 300;
@@ -478,24 +488,24 @@ p.summary.drop-cap:first-letter {
   text-align: center;
   margin: 0 2em 4em; }
 
-/* line 188, ../scss/components/_soe_wysiwyg.scss */
+/* line 195, ../scss/components/_soe_wysiwyg.scss */
 .main table {
   width: 100%;
   margin-bottom: 2em; }
-/* line 194, ../scss/components/_soe_wysiwyg.scss */
+/* line 201, ../scss/components/_soe_wysiwyg.scss */
 .main p.float-left {
   margin-right: 15px; }
-/* line 198, ../scss/components/_soe_wysiwyg.scss */
+/* line 205, ../scss/components/_soe_wysiwyg.scss */
 .main p.float-right {
   margin-left: 15px; }
 
 @media (max-width: 767px) {
-  /* line 205, ../scss/components/_soe_wysiwyg.scss */
+  /* line 212, ../scss/components/_soe_wysiwyg.scss */
   .field-type-text-with-summary h2, .field-type-text-long h2 {
     font-size: 1.2em; } }
 
 @media (max-width: 767px) {
-  /* line 214, ../scss/components/_soe_wysiwyg.scss */
+  /* line 221, ../scss/components/_soe_wysiwyg.scss */
   .field-type-text-with-summary h3, .field-type-text-long h3 {
     font-size: 1em; } }
 
@@ -1285,13 +1295,14 @@ p.summary.drop-cap:first-letter {
   padding: 0; }
 /* line 13, ../scss/components/_soe_homepage.scss */
 .front [id*="block-bean-homepage-2-column-"] .content {
-  width: 93%;
+  width: 85%;
   margin: 0 auto 50px; }
   @media (max-width: 767px) {
     /* line 13, ../scss/components/_soe_homepage.scss */
     .front [id*="block-bean-homepage-2-column-"] .content {
-      margin-bottom: 20px; } }
-  /* line 20, ../scss/components/_soe_homepage.scss */
+      margin-bottom: 20px;
+      width: 95%; } }
+  /* line 21, ../scss/components/_soe_homepage.scss */
   .front [id*="block-bean-homepage-2-column-"] .content a:not(.btn) {
     color: #333333;
     text-decoration: underline;
@@ -1299,83 +1310,83 @@ p.summary.drop-cap:first-letter {
     text-decoration-skip: ink;
     -webkit-text-decoration-color: #00ECE9;
     text-decoration-color: #00ECE9; }
-    /* line 26, ../scss/components/_soe_homepage.scss */
+    /* line 27, ../scss/components/_soe_homepage.scss */
     .front [id*="block-bean-homepage-2-column-"] .content a:not(.btn):focus, .front [id*="block-bean-homepage-2-column-"] .content a:not(.btn):hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
-  /* line 32, ../scss/components/_soe_homepage.scss */
+  /* line 33, ../scss/components/_soe_homepage.scss */
   .front [id*="block-bean-homepage-2-column-"] .content p.columns {
     margin-bottom: 50px; }
     @media (max-width: 767px) {
-      /* line 32, ../scss/components/_soe_homepage.scss */
+      /* line 33, ../scss/components/_soe_homepage.scss */
       .front [id*="block-bean-homepage-2-column-"] .content p.columns {
         margin-top: -36px;
         margin-bottom: 30px; } }
     @media (max-width: 580px) {
-      /* line 32, ../scss/components/_soe_homepage.scss */
+      /* line 33, ../scss/components/_soe_homepage.scss */
       .front [id*="block-bean-homepage-2-column-"] .content p.columns {
         font-size: 1.1em; } }
     @media (max-width: 480px) {
-      /* line 32, ../scss/components/_soe_homepage.scss */
+      /* line 33, ../scss/components/_soe_homepage.scss */
       .front [id*="block-bean-homepage-2-column-"] .content p.columns {
         line-height: 1.5em; } }
-/* line 50, ../scss/components/_soe_homepage.scss */
+/* line 51, ../scss/components/_soe_homepage.scss */
 .front .bean-stanford-postcard-linked .postcard-linked-container,
 .front .view-stanford-page-banner-caption {
   margin-bottom: 100px; }
   @media (max-width: 767px) {
-    /* line 50, ../scss/components/_soe_homepage.scss */
+    /* line 51, ../scss/components/_soe_homepage.scss */
     .front .bean-stanford-postcard-linked .postcard-linked-container,
     .front .view-stanford-page-banner-caption {
       margin-bottom: 30px; } }
-/* line 59, ../scss/components/_soe_homepage.scss */
+/* line 60, ../scss/components/_soe_homepage.scss */
 .front .view-stanford-ppl-spot-fw-banner-quote {
   margin-bottom: 60px; }
-/* line 63, ../scss/components/_soe_homepage.scss */
+/* line 64, ../scss/components/_soe_homepage.scss */
 .front #block-bean-homepage-magazine-postcard-butto {
   margin: 80px 0 60px; }
-/* line 67, ../scss/components/_soe_homepage.scss */
+/* line 68, ../scss/components/_soe_homepage.scss */
 .front #block-bean-stanford-soe-mailchimp-homepage- {
   margin-bottom: 80px; }
-/* line 71, ../scss/components/_soe_homepage.scss */
+/* line 72, ../scss/components/_soe_homepage.scss */
 .front .mailchimp-magazine-block #mc_embed_signup_scroll {
   padding: 50px; }
-  /* line 74, ../scss/components/_soe_homepage.scss */
+  /* line 75, ../scss/components/_soe_homepage.scss */
   .front .mailchimp-magazine-block #mc_embed_signup_scroll h2 {
     margin-bottom: 0; }
-  /* line 78, ../scss/components/_soe_homepage.scss */
+  /* line 79, ../scss/components/_soe_homepage.scss */
   .front .mailchimp-magazine-block #mc_embed_signup_scroll p {
     margin-bottom: 1.8em; }
-/* line 84, ../scss/components/_soe_homepage.scss */
+/* line 85, ../scss/components/_soe_homepage.scss */
 .front [id*="block-bean-homepage-pl-block-1"],
 .front [id*="block-views-0969cf96ba3c89e5f5ea0784f69f7372"] {
   margin-left: 12.75%; }
   @media (max-width: 767px) {
-    /* line 84, ../scss/components/_soe_homepage.scss */
+    /* line 85, ../scss/components/_soe_homepage.scss */
     .front [id*="block-bean-homepage-pl-block-1"],
     .front [id*="block-views-0969cf96ba3c89e5f5ea0784f69f7372"] {
       margin-left: 0;
       margin: 0 auto;
       width: 95%; } }
 @media (max-width: 767px) {
-  /* line 94, ../scss/components/_soe_homepage.scss */
+  /* line 95, ../scss/components/_soe_homepage.scss */
   .front [id*="block-bean-homepage-pl-block-2"],
   .front .view-stanford-news-featured {
     margin: 0 auto;
     width: 95%; } }
-/* line 102, ../scss/components/_soe_homepage.scss */
+/* line 103, ../scss/components/_soe_homepage.scss */
 .front [id*="block-bean-homepage-pl-block-3"],
 .front [id*="block-views-stanford-event-featured-block-1"] {
   margin-right: 12.75%; }
   @media (max-width: 767px) {
-    /* line 102, ../scss/components/_soe_homepage.scss */
+    /* line 103, ../scss/components/_soe_homepage.scss */
     .front [id*="block-bean-homepage-pl-block-3"],
     .front [id*="block-views-stanford-event-featured-block-1"] {
       margin-right: 0;
       margin: 0 auto;
       width: 95%; } }
 @media (max-width: 580px) {
-  /* line 112, ../scss/components/_soe_homepage.scss */
+  /* line 113, ../scss/components/_soe_homepage.scss */
   .front [id*="block-bean-homepage-magazine-postcard-butto"] {
     margin: 30px 0 30px; } }
 
@@ -4030,56 +4041,59 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
 .node-type-stanford-magazine-article .paragraphs-item-p-two-columns {
   font-family: "Roboto Slab", serif;
   font-size: 1.4em;
-  margin-bottom: 1em; }
+  margin: 0 auto;
+  column-count: 1;
+  column-gap: 0;
+  width: 85%; }
 @media (max-width: 480px) {
-  /* line 904, ../scss/components/_soe_dm_article.scss */
+  /* line 907, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article h1 {
     width: 100%; } }
-/* line 911, ../scss/components/_soe_dm_article.scss */
+/* line 914, ../scss/components/_soe_dm_article.scss */
 .node-type-stanford-magazine-article .paragraphs-item-p-wysiwyg-simple a {
   text-decoration: underline; }
 @media (max-width: 979px) {
-  /* line 910, ../scss/components/_soe_dm_article.scss */
+  /* line 913, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .paragraphs-item-p-wysiwyg-simple {
     width: 85%; } }
 @media (max-width: 480px) {
-  /* line 910, ../scss/components/_soe_dm_article.scss */
+  /* line 913, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .paragraphs-item-p-wysiwyg-simple {
     width: 100%; } }
 
-/* line 924, ../scss/components/_soe_dm_article.scss */
+/* line 927, ../scss/components/_soe_dm_article.scss */
 .entity-paragraphs-item iframe {
   width: 100%; }
-  /* line 926, ../scss/components/_soe_dm_article.scss */
+  /* line 929, ../scss/components/_soe_dm_article.scss */
   .entity-paragraphs-item iframe.iframe-auto {
     height: auto; }
-/* line 931, ../scss/components/_soe_dm_article.scss */
+/* line 934, ../scss/components/_soe_dm_article.scss */
 .entity-paragraphs-item iframe[src*="youtube"],
 .entity-paragraphs-item iframe[src*="vimeo"] {
   height: 400px; }
 
-/* line 940, ../scss/components/_soe_dm_article.scss */
+/* line 943, ../scss/components/_soe_dm_article.scss */
 #block-ds-extras-related-departments {
   width: 85%;
   border-top: 1px solid #CCCCCC;
   margin: 0 auto 80px;
   padding-top: 20px; }
   @media (max-width: 480px) {
-    /* line 940, ../scss/components/_soe_dm_article.scss */
+    /* line 943, ../scss/components/_soe_dm_article.scss */
     #block-ds-extras-related-departments {
       width: 100%; } }
-  /* line 949, ../scss/components/_soe_dm_article.scss */
+  /* line 952, ../scss/components/_soe_dm_article.scss */
   #block-ds-extras-related-departments h2 {
     font-size: 0.9em;
     font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
     margin-bottom: 0; }
-  /* line 955, ../scss/components/_soe_dm_article.scss */
+  /* line 958, ../scss/components/_soe_dm_article.scss */
   #block-ds-extras-related-departments .field-name-field-s-mag-article-dept {
     font-size: 0.9em;
     line-height: 1.3em;
     width: 45%; }
     @media (max-width: 480px) {
-      /* line 955, ../scss/components/_soe_dm_article.scss */
+      /* line 958, ../scss/components/_soe_dm_article.scss */
       #block-ds-extras-related-departments .field-name-field-s-mag-article-dept {
         width: 100%; } }
 

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -438,6 +438,8 @@ p.columns {
     .group-p-ws-style p.columns p.columns {
       font-size: 1.2em;
       line-height: 1.6em;
+      -webkit-column-count: 1;
+      -moz-column-count: 1;
       column-count: 1;
       padding: 0 50px; }
 

--- a/scss/components/_soe_dm_article.scss
+++ b/scss/components/_soe_dm_article.scss
@@ -898,7 +898,10 @@
   .paragraphs-item-p-two-columns {
     font-family: $roboto-slab;
     font-size: em(28px);
-    margin-bottom: 1em;
+    margin: 0 auto;
+    column-count: 1;
+    column-gap: 0;
+    width: 85%;
   }
 
   h1 {

--- a/scss/components/_soe_global.scss
+++ b/scss/components/_soe_global.scss
@@ -271,6 +271,10 @@ th {
   p {
     margin: 0 0 1.5em;
 
+    &.columns {
+      column-count: 1;
+      column-gap: 0;
+    }
     a {
       text-decoration: underline;
 

--- a/scss/components/_soe_homepage.scss
+++ b/scss/components/_soe_homepage.scss
@@ -11,10 +11,11 @@
 
   [id*="block-bean-homepage-2-column-"] {
     .content {
-      width: 93%;
+      width: 85%;
       margin: 0 auto 50px;
       @include breakpoint-max(small) {
         margin-bottom: 20px;
+        width: 95%;
       }
 
       a:not(.btn) {

--- a/scss/components/_soe_wysiwyg.scss
+++ b/scss/components/_soe_wysiwyg.scss
@@ -122,8 +122,8 @@ p.columns {
   font-size: em(1.4em);
   line-height: 1.6em;
   font-weight: bold;
-  @include column-count (2);
-  @include column-gap (80px);
+  @include column-count (1);
+  @include column-gap (0);
   @include breakpoint-max(small) {
      @include column-count (1);
   }
@@ -132,6 +132,13 @@ p.columns {
     line-height: 1.6em;
     padding: 0 50px;
     @include column-count (1);
+
+    p.columns {
+      font-size: 1.2em;
+      line-height: 1.6em;
+      column-count: 1;
+      padding: 0 50px;
+    }
   }
 }
 

--- a/scss/components/_soe_wysiwyg.scss
+++ b/scss/components/_soe_wysiwyg.scss
@@ -136,7 +136,7 @@ p.columns {
     p.columns {
       font-size: 1.2em;
       line-height: 1.6em;
-      column-count: 1;
+      @include column-count (1);
       padding: 0 50px;
     }
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
This adds the Collections Injector file 44 into SCSS.

# Needed By (Date)
- Sprint end

# Criticality
- Collections Injector file 44 into SCSS


# Steps to Test
- Switch to this branch  -  7.x-2.x-SOE-2987-merged (https://github.com/SU-SOE/stanford_soe_helper/tree/7.x-2.x-SOE-2987-merged)
- delete this injector: `admin/config/development/css-injector/edit/44`
- `drush cc all`
- go to: `/`, `magazine/article/researchers-build-water-based-battery-store-solar-and-wind-energy`,  and `magazine/article/researchers-analyze-friendship-networks-infer-hidden-traits`.
- make sure the css is showing.

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-2987

## Related PRs

## More Information

## Folks to notify
@cjwest and @boznik 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)