### PR TITLE
7.x 2.x soe 3296 hide edit

### DIFF
--- a/modules/stanford_people_spotlight/stanford_people_spotlight.info
+++ b/modules/stanford_people_spotlight/stanford_people_spotlight.info
@@ -6,6 +6,7 @@ version = 7.x-2.1-dev
 project = stanford_people_spotlight
 dependencies[] = ctools
 dependencies[] = date
+dependencies[] = entityreference
 dependencies[] = features
 dependencies[] = field_group
 dependencies[] = image

--- a/modules/stanford_people_spotlight_views/stanford_people_spotlight_views.views_default.inc
+++ b/modules/stanford_people_spotlight_views/stanford_people_spotlight_views.views_default.inc
@@ -2335,11 +2335,14 @@ function stanford_people_spotlight_views_views_default_views() {
   $handler->display->display_options['fields']['edit_node']['field'] = 'edit_node';
   $handler->display->display_options['fields']['edit_node']['label'] = '';
   $handler->display->display_options['fields']['edit_node']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['edit_node']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['edit_node']['alter']['text'] = '<div class="edit-link">[edit_node]</div>';
   $handler->display->display_options['fields']['edit_node']['element_type'] = 'div';
   $handler->display->display_options['fields']['edit_node']['element_class'] = 'edit-link';
   $handler->display->display_options['fields']['edit_node']['element_label_type'] = 'div';
   $handler->display->display_options['fields']['edit_node']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['edit_node']['element_wrapper_type'] = 'div';
+  $handler->display->display_options['fields']['edit_node']['hide_empty'] = TRUE;
   /* Field: Global: View rewrite */
   $handler->display->display_options['fields']['nothing']['id'] = 'nothing';
   $handler->display->display_options['fields']['nothing']['table'] = 'views';
@@ -2365,7 +2368,7 @@ function stanford_people_spotlight_views_views_default_views() {
         <p>[field_s_ppl_spot_department]</p>
       </div>
       [field_s_ppl_spot_quote_1]
-      <div class="edit-link">[edit_node]</div>
+      [edit_node]
     </div>
   </div>
 </div>
@@ -2852,11 +2855,14 @@ function stanford_people_spotlight_views_views_default_views() {
   $handler->display->display_options['fields']['edit_node']['field'] = 'edit_node';
   $handler->display->display_options['fields']['edit_node']['label'] = '';
   $handler->display->display_options['fields']['edit_node']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['edit_node']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['edit_node']['alter']['text'] = ' <div class="edit-link">[edit_node]</div>';
   $handler->display->display_options['fields']['edit_node']['element_type'] = 'div';
   $handler->display->display_options['fields']['edit_node']['element_class'] = 'edit-link';
   $handler->display->display_options['fields']['edit_node']['element_label_type'] = 'div';
   $handler->display->display_options['fields']['edit_node']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['edit_node']['element_wrapper_type'] = 'div';
+  $handler->display->display_options['fields']['edit_node']['hide_empty'] = TRUE;
   /* Field: Global: View rewrite */
   $handler->display->display_options['fields']['nothing']['id'] = 'nothing';
   $handler->display->display_options['fields']['nothing']['table'] = 'views';
@@ -2882,7 +2888,7 @@ function stanford_people_spotlight_views_views_default_views() {
         <p>[field_s_ppl_spot_department]</p>
        </div>
       [field_s_ppl_spot_quote_1]
-      <div class="edit-link">[edit_node]</div>
+      [edit_node]
     </div>
   </div>
 </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- See ticket: https://stanfordits.atlassian.net/browse/SOE-3296
This hides the edit link <div> for anonymous users in Spotlight views.
This also captures overrides for spotlight. Basically, it captures into code a new dependency on the Entity Reference module, and it should no longer be overridden.
- See Shea's comment: See https://github.com/SU-SOE/stanford_soe_helper/pull/206#issuecomment-405400535 

# Needed By (Date)
- Sprint end

# Criticality
- Fixes broken stuff


# Steps to Test
If necessary clone this to `sites/default/modules/stanford`
`$ git clone git@github.com:SU-SOE/stanford_soe_helper.git`
Check out this branch:
`$ git checkout 7.x-2.x-soe-3296-hide-edit`
`$ drush rr`
As an anonymous user navigate to `spotlight`
Verify that the `edit-link` class does not appear on the page
See screenshots in ticket:
https://stanfordits.atlassian.net/browse/SOE-3296

**Note**: If you're using php 7.1, there's some updates to the site that are needed for the site to work properly. I'm tracking them in this script:
https://github.com/cjwest/scripts/blob/master/make-local-dev.sh

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-3296

## Related PRs
https://github.com/SU-SOE/stanford_soe_helper/pull/206#issuecomment-405400535 

## More Information

## Folks to notify
@kerri-augenstein @annawatt 


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)