### PR TITLE
SOE-3304 address h spotlight responsive bug and cleaned up grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,6 @@ module.exports = function(grunt) {
     }
   });
   grunt.loadNpmTasks('grunt-sass');
-  grunt.loadNpmTasks('grunt-contrib-sass');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.registerTask('default', ['watch']);
 }

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -1,31 +1,25 @@
 @charset "UTF-8";
 @import url(https://fonts.googleapis.com/css?family=Roboto+Slab:400,700,300,100);
-/* line 8, ../scss/components/_soe_global.scss */
 html {
   font-size: 62.5%; }
 
-/* line 12, ../scss/components/_soe_global.scss */
 body {
   font-size: 2em;
   font-weight: 400;
   line-height: 1.55em; }
   @media (max-width: 979px) {
-    /* line 12, ../scss/components/_soe_global.scss */
     body {
       font-size: 19px;
       font-size: 1.9em; } }
   @media (max-width: 767px) {
-    /* line 12, ../scss/components/_soe_global.scss */
     body {
       font-size: 18px;
       font-size: 1.8em; } }
   @media (max-width: 480px) {
-    /* line 12, ../scss/components/_soe_global.scss */
     body {
       font-size: 17px;
       font-size: 1.7em; } }
 
-/* line 30, ../scss/components/_soe_global.scss */
 h1 {
   font-family: "Roboto Slab", serif;
   font-size: 2.8em;
@@ -33,47 +27,38 @@ h1 {
   letter-spacing: 0;
   margin: -9px 0 10px; }
   @media (max-width: 979px) {
-    /* line 30, ../scss/components/_soe_global.scss */
     h1 {
       font-size: 2.3em; } }
   @media (max-width: 767px) {
-    /* line 30, ../scss/components/_soe_global.scss */
     h1 {
       font-size: 2em; } }
   @media (max-width: 480px) {
-    /* line 30, ../scss/components/_soe_global.scss */
     h1 {
       font-size: 1.8em; } }
 
-/* line 47, ../scss/components/_soe_global.scss */
 h2 {
   font-family: "Roboto Slab", serif;
   font-size: 1.6em;
   font-weight: 600;
   letter-spacing: 0;
   margin: 1.8em 0 0.5em; }
-  /* line 54, ../scss/components/_soe_global.scss */
   h2 a {
     font-weight: 600; }
 
-/* line 59, ../scss/components/_soe_global.scss */
 h3 {
   font-family: "Roboto Slab", serif;
   font-size: 1.2em;
   font-weight: 600;
   margin: 1.6em 0 0.3em; }
-  /* line 65, ../scss/components/_soe_global.scss */
   h3 a {
     font-weight: 600; }
 
-/* line 70, ../scss/components/_soe_global.scss */
 h4 {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 1.1em;
   font-weight: 600;
   margin: 1em 0 0.5em; }
 
-/* line 83, ../scss/components/_soe_global.scss */
 h1 a,
 h2 a,
 h3 a,
@@ -81,7 +66,6 @@ h4 a,
 h5 a,
 h6 a {
   text-decoration: underline; }
-  /* line 86, ../scss/components/_soe_global.scss */
   h1 a:focus, h1 a:hover,
   h2 a:focus,
   h2 a:hover,
@@ -95,16 +79,13 @@ h6 a {
   h6 a:hover {
     text-decoration: underline; }
 
-/* line 94, ../scss/components/_soe_global.scss */
 p.columns a {
   font-weight: bold; }
 
-/* line 99, ../scss/components/_soe_global.scss */
 iframe {
   margin: 20px 0;
   min-width: 100%; }
 
-/* line 104, ../scss/components/_soe_global.scss */
 .btn a,
 a.btn {
   border-radius: 0;
@@ -117,12 +98,10 @@ a.btn {
   font-size: 1.9rem;
   padding: 0.8em 1.2em 0.9em;
   background: #B1040E; }
-  /* line 115, ../scss/components/_soe_global.scss */
   .btn a:focus, .btn a:hover,
   a.btn:focus,
   a.btn:hover {
     color: #FFFFFF; }
-  /* line 120, ../scss/components/_soe_global.scss */
   #content-body .content .btn a, #content-body .content
   a.btn {
     display: block;
@@ -131,74 +110,62 @@ a.btn {
     margin-bottom: 30px;
     text-decoration: none; }
     @media (max-width: 480px) {
-      /* line 120, ../scss/components/_soe_global.scss */
       #content-body .content .btn a, #content-body .content
       a.btn {
         width: 65%; } }
 
-/* line 132, ../scss/components/_soe_global.scss */
 .normal-link a,
 a {
   color: #B1040E; }
 
-/* line 137, ../scss/components/_soe_global.scss */
 div.more-link {
   font-size: 1em; }
 
-/* line 141, ../scss/components/_soe_global.scss */
 .more-link a,
 a.more-link {
   font-size: 0.9em;
   color: #B1040E; }
-  /* line 146, ../scss/components/_soe_global.scss */
   .more-link a:after,
   a.more-link:after {
     content: " ›"; }
 
-/* line 151, ../scss/components/_soe_global.scss */
 .normal-link h2,
 .normal-link h3,
 h2.normal-link,
 h3.normal-link {
   font-size: 1.1em; }
 
-/* line 158, ../scss/components/_soe_global.scss */
 li {
   line-height: 1.4em;
   margin-bottom: 16px; }
 
-/* line 164, ../scss/components/_soe_global.scss */
 .content ul li {
   list-style-type: disc; }
-  /* line 167, ../scss/components/_soe_global.scss */
   .content ul li:last-child {
     margin-bottom: 1.5em; }
-/* line 173, ../scss/components/_soe_global.scss */
+
 .content ol li:last-child {
   margin-bottom: 2em; }
-/* line 180, ../scss/components/_soe_global.scss */
+
 .content ul.pager li a {
   border: 1px solid #D7D7D7;
   background: #FFFFFF;
   margin-bottom: 12px;
   margin-right: 4px;
   font-size: 0.9em; }
-  /* line 187, ../scss/components/_soe_global.scss */
   .content ul.pager li a:focus, .content ul.pager li a:hover {
     margin-right: 4px;
     font-weight: 300; }
-/* line 194, ../scss/components/_soe_global.scss */
+
 .content ul.pager li.pager-current {
   margin-right: 4px;
   font-weight: 300; }
-/* line 200, ../scss/components/_soe_global.scss */
+
 .content ul.pager.pager-load-more {
   margin-bottom: 100px; }
   @media (max-width: 767px) {
-    /* line 200, ../scss/components/_soe_global.scss */
     .content ul.pager.pager-load-more {
       margin-bottom: 50px; } }
-  /* line 206, ../scss/components/_soe_global.scss */
   .content ul.pager.pager-load-more a {
     color: #FFFFFF;
     font-size: 1em;
@@ -211,13 +178,11 @@ li {
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     padding: 0.7em 4em;
     margin-bottom: 0; }
-    /* line 217, ../scss/components/_soe_global.scss */
     .content ul.pager.pager-load-more a:focus, .content ul.pager.pager-load-more a:hover {
       color: #FFFFFF;
       background-color: #333333;
       font-weight: 400; }
 
-/* line 228, ../scss/components/_soe_global.scss */
 td,
 th {
   padding: 0.8em;
@@ -227,28 +192,23 @@ th {
   border-right: none;
   border-left: none; }
 
-/* line 238, ../scss/components/_soe_global.scss */
 th {
   background: #EFEFEF; }
 
-/* line 242, ../scss/components/_soe_global.scss */
 .well {
   background: #FFFFFF;
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 246, ../scss/components/_soe_global.scss */
   .well h2 {
     font-size: 1.6em;
     font-weight: 600;
     margin-bottom: 1.1em; }
-  /* line 252, ../scss/components/_soe_global.scss */
   .well p {
     font-size: 1em;
     font-weight: 400;
     line-height: 1.5em; }
 
-/* line 259, ../scss/components/_soe_global.scss */
 .descriptor {
   font-size: 0.9em;
   line-height: 1.2em;
@@ -256,72 +216,55 @@ th {
   text-transform: none;
   margin-bottom: 4px; }
 
-/* line 267, ../scss/components/_soe_global.scss */
 .postcard-left {
   margin-top: 6px; }
 
-/* line 271, ../scss/components/_soe_global.scss */
 .views-row-lines .views-row {
   border-color: #D7D7D7; }
 
-/* line 275, ../scss/components/_soe_global.scss */
 #wrap {
   background: #F8F8F8; }
 
-/* line 279, ../scss/components/_soe_global.scss */
 .main {
   padding: 80px 0 50px;
   background: #F8F8F8; }
   @media (max-width: 767px) {
-    /* line 279, ../scss/components/_soe_global.scss */
     .main {
       padding: 40px 0 0; } }
-  /* line 286, ../scss/components/_soe_global.scss */
   .main p {
     margin: 0 0 1.5em; }
-    /* line 289, ../scss/components/_soe_global.scss */
     .main p.columns {
       column-count: 1;
       column-gap: 0; }
-    /* line 293, ../scss/components/_soe_global.scss */
     .main p a {
       text-decoration: underline; }
-      /* line 296, ../scss/components/_soe_global.scss */
       .main p a.btn {
         text-decoration: none; }
-  /* line 302, ../scss/components/_soe_global.scss */
   .main .block {
     margin-bottom: 50px; }
 
 @media (max-width: 767px) {
-  /* line 307, ../scss/components/_soe_global.scss */
   .container {
     margin-bottom: 10px; }
-    /* line 311, ../scss/components/_soe_global.scss */
     #fullwidth-bottom .container {
       margin-bottom: 0; } }
 
 @media (min-width: 1200px) {
-  /* line 317, ../scss/components/_soe_global.scss */
   #content.span9 {
     width: 740px;
     margin-left: 80px; } }
 
 /*** BODY - MORE SPACE FROM LAST CHILD TO TOP OF BLOCKS AFTER WYSIWYG ***/
-/* line 325, ../scss/components/_soe_global.scss */
 .content-body p:last-child {
   margin-bottom: 2.5em; }
 
-/* line 329, ../scss/components/_soe_global.scss */
 .region-sidebar-second {
   margin-top: 34px; }
 
 /*** Full width region ***/
-/* line 335, ../scss/components/_soe_global.scss */
 .region-fullwidth-top #block-ds-extras-featured-image img {
   width: 100%; }
 
-/* line 7, ../scss/components/_soe_wysiwyg.scss */
 .summary {
   font-family: "Roboto Slab", serif;
   font-size: 1.6em;
@@ -329,85 +272,75 @@ th {
   line-height: 1.5em;
   margin-bottom: 40px; }
   @media (max-width: 1200px) {
-    /* line 7, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.4em; } }
   @media (max-width: 979px) {
-    /* line 7, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.3em; } }
   @media (max-width: 767px) {
-    /* line 7, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.2em; } }
   @media (max-width: 480px) {
-    /* line 7, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.1em; } }
 
-/* line 28, ../scss/components/_soe_wysiwyg.scss */
 a[class*="btn-"] {
   color: #000000; }
-  /* line 31, ../scss/components/_soe_wysiwyg.scss */
   .node-type-stanford-event a[class*="btn-"] {
     color: #FFFFFF; }
-/* line 36, ../scss/components/_soe_wysiwyg.scss */
+
 a.btn-orange {
   background: #FFBD54; }
-/* line 40, ../scss/components/_soe_wysiwyg.scss */
+
 a.btn-turquoise {
   background: #00ECE9; }
-/* line 44, ../scss/components/_soe_wysiwyg.scss */
+
 a.btn-pink {
   background: #FF525C; }
-/* line 49, ../scss/components/_soe_wysiwyg.scss */
+
 a.external-link:after {
   content: url("../img/soe_external_link_icon_red.svg");
   padding-left: 5px;
   vertical-align: -2%; }
-/* line 55, ../scss/components/_soe_wysiwyg.scss */
+
 a.external-link:focus:after, a.external-link:hover:after {
   content: url("../img/soe_external_link_icon_black.svg"); }
-/* line 61, ../scss/components/_soe_wysiwyg.scss */
+
 a.btn.external-link:after {
   content: url("../img/soe_external_link_icon_white.svg");
   padding-left: 5px;
   vertical-align: -2%; }
-/* line 68, ../scss/components/_soe_wysiwyg.scss */
+
 a[class*="btn-"].btn.external-link:after {
   content: url("../img/soe_external_link_icon_black.svg");
   padding-left: 5px;
   vertical-align: -2%; }
-/* line 74, ../scss/components/_soe_wysiwyg.scss */
+
 a[class*="btn-"].btn.external-link:focus:after, a[class*="btn-"].btn.external-link:hover:after {
   content: url("../img/soe_external_link_icon_white.svg"); }
-/* line 80, ../scss/components/_soe_wysiwyg.scss */
-a.private-link, .private-link a {
+
+a.private-link,
+.private-link a {
   font-size: 18px;
   font-weight: 400; }
-  /* line 85, ../scss/components/_soe_wysiwyg.scss */
-  a.private-link:after, .private-link a:after {
+  a.private-link:after,
+  .private-link a:after {
     background-image: url("../img/soe_lock_black.svg");
     background-size: 13px 16px;
     background-position: center;
     padding-left: 13px;
     margin-left: 5px; }
 
-/* line 95, ../scss/components/_soe_wysiwyg.scss */
 p.btn-center {
   text-align: center; }
-  /* line 98, ../scss/components/_soe_wysiwyg.scss */
   p.btn-center a.btn {
     margin-right: 40px; }
     @media (max-width: 767px) {
-      /* line 98, ../scss/components/_soe_wysiwyg.scss */
       p.btn-center a.btn {
         margin-right: 10px; } }
-    /* line 104, ../scss/components/_soe_wysiwyg.scss */
     p.btn-center a.btn:last-child {
       margin-right: 0; }
 
-/* line 110, ../scss/components/_soe_wysiwyg.scss */
 p.highlight {
   border: none;
   -webkit-column-count: 1;
@@ -419,7 +352,6 @@ p.highlight {
   line-height: 1.6em;
   padding: 0 50px; }
 
-/* line 120, ../scss/components/_soe_wysiwyg.scss */
 p.columns {
   font-family: "Roboto Slab", serif;
   font-size: 1.4em;
@@ -432,12 +364,10 @@ p.columns {
   -moz-column-gap: 0;
   column-gap: 0; }
   @media (max-width: 767px) {
-    /* line 120, ../scss/components/_soe_wysiwyg.scss */
     p.columns {
       -webkit-column-count: 1;
       -moz-column-count: 1;
       column-count: 1; } }
-  /* line 130, ../scss/components/_soe_wysiwyg.scss */
   .group-p-ws-style p.columns {
     font-size: 1.2em;
     line-height: 1.6em;
@@ -445,7 +375,6 @@ p.columns {
     -webkit-column-count: 1;
     -moz-column-count: 1;
     column-count: 1; }
-    /* line 136, ../scss/components/_soe_wysiwyg.scss */
     .group-p-ws-style p.columns p.columns {
       font-size: 1.2em;
       line-height: 1.6em;
@@ -454,7 +383,6 @@ p.columns {
       column-count: 1;
       padding: 0 50px; }
 
-/* line 145, ../scss/components/_soe_wysiwyg.scss */
 p.related-link {
   background: #FFFFFF;
   line-height: 1.3em;
@@ -462,37 +390,29 @@ p.related-link {
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 151, ../scss/components/_soe_wysiwyg.scss */
   p.related-link a {
     text-decoration: none; }
-    /* line 154, ../scss/components/_soe_wysiwyg.scss */
     p.related-link a:focus, p.related-link a:hover {
       text-decoration: underline; }
-  /* line 160, ../scss/components/_soe_wysiwyg.scss */
   p.related-link:before {
     content: "Related \00a0 | \00a0";
     font-weight: 600; }
 
-/* line 167, ../scss/components/_soe_wysiwyg.scss */
 p.summary.drop-cap:first-letter {
   padding: 25px 10px 0 0;
   font-size: 2.875em;
   font-weight: 600;
   float: left; }
   @media (max-width: 1200px) {
-    /* line 167, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 21px 10px 0 0; } }
   @media (max-width: 979px) {
-    /* line 167, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 16px 10px 0 0; } }
   @media (max-width: 480px) {
-    /* line 167, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 15px 10px 0 0; } }
 
-/* line 185, ../scss/components/_soe_wysiwyg.scss */
 .caption {
   color: #606060;
   font-weight: 300;
@@ -501,256 +421,220 @@ p.summary.drop-cap:first-letter {
   text-align: center;
   margin: 0 2em 4em; }
 
-/* line 195, ../scss/components/_soe_wysiwyg.scss */
 .main table {
   width: 100%;
   margin-bottom: 2em; }
-/* line 201, ../scss/components/_soe_wysiwyg.scss */
+
 .main p.float-left {
   margin-right: 15px; }
-/* line 205, ../scss/components/_soe_wysiwyg.scss */
+
 .main p.float-right {
   margin-left: 15px; }
 
 @media (max-width: 767px) {
-  /* line 212, ../scss/components/_soe_wysiwyg.scss */
-  .field-type-text-with-summary h2, .field-type-text-long h2 {
+  .field-type-text-with-summary h2,
+  .field-type-text-long h2 {
     font-size: 1.2em; } }
 
 @media (max-width: 767px) {
-  /* line 221, ../scss/components/_soe_wysiwyg.scss */
-  .field-type-text-with-summary h3, .field-type-text-long h3 {
+  .field-type-text-with-summary h3,
+  .field-type-text-long h3 {
     font-size: 1em; } }
 
-/* line 7, ../scss/components/_soe_brand_bar.scss */
 #global-header {
   background-color: #B1040E; }
-  /* line 10, ../scss/components/_soe_brand_bar.scss */
   .dm-global-header #global-header {
     position: absolute;
     clip: rect(0 9999px 2px 0);
     clip-path: inset(0 0 55px 0);
     width: 100%; }
     @media (max-width: 767px) {
-      /* line 10, ../scss/components/_soe_brand_bar.scss */
       .dm-global-header #global-header {
         clip-path: inset(0 0 60px 0); } }
-  /* line 21, ../scss/components/_soe_brand_bar.scss */
   #global-header .container {
     padding: 13px 0;
     margin-bottom: 0; }
 
-/* line 30, ../scss/components/_soe_brand_bar.scss */
 #header #logo.logo-mobile img,
 #header #logo img {
   max-width: 160px; }
   @media (max-width: 480px) {
-    /* line 30, ../scss/components/_soe_brand_bar.scss */
     #header #logo.logo-mobile img,
     #header #logo img {
       max-width: 130px; } }
   @media (max-width: 400px) {
-    /* line 30, ../scss/components/_soe_brand_bar.scss */
     #header #logo.logo-mobile img,
     #header #logo img {
       max-width: 90px; } }
   @media (max-width: 380px) {
-    /* line 30, ../scss/components/_soe_brand_bar.scss */
     #header #logo.logo-mobile img,
     #header #logo img {
       max-width: 80px; } }
-/* line 44, ../scss/components/_soe_brand_bar.scss */
+
 #header #logo.logo-mobile {
   padding: 0 5px 0 0; }
   @media (max-width: 480px) {
-    /* line 44, ../scss/components/_soe_brand_bar.scss */
     #header #logo.logo-mobile {
       display: table-cell;
       padding: 0 10px 0 0;
       border-right: 1px solid !important; }
-      /* line 51, ../scss/components/_soe_brand_bar.scss */
       #header #logo.logo-mobile a {
         background-size: 120px 26.66px; } }
   @media (max-width: 400px) {
-    /* line 44, ../scss/components/_soe_brand_bar.scss */
     #header #logo.logo-mobile {
       padding: 0 5px 0 0; } }
-/* line 62, ../scss/components/_soe_brand_bar.scss */
+
 #header #name-and-slogan.with-logo {
   padding: 0 0 0 5px; }
   @media (max-width: 480px) {
-    /* line 62, ../scss/components/_soe_brand_bar.scss */
     #header #name-and-slogan.with-logo {
       display: table-cell;
       padding: 0 0 0 10px; } }
   @media (max-width: 400px) {
-    /* line 62, ../scss/components/_soe_brand_bar.scss */
     #header #name-and-slogan.with-logo {
       padding: 0 0 0 5px; } }
-/* line 73, ../scss/components/_soe_brand_bar.scss */
+
 #header.header {
   background: #FFFFFF;
   padding: 30px 0 0; }
   @media (max-width: 480px) {
-    /* line 73, ../scss/components/_soe_brand_bar.scss */
     #header.header {
       min-height: 60px;
       padding: 35px 0 0; } }
   @media (max-width: 400px) {
-    /* line 73, ../scss/components/_soe_brand_bar.scss */
     #header.header {
       min-height: 40px;
       padding: 22px 0 0; } }
-  /* line 87, ../scss/components/_soe_brand_bar.scss */
   #header.header #site-title-first-line.site-title-uppercase a {
     font-size: 36px; }
     @media (max-width: 480px) {
-      /* line 87, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase a {
         font-size: 28px;
         margin-bottom: -5px; } }
     @media (max-width: 400px) {
-      /* line 87, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase a {
         font-size: 18px;
         margin-bottom: -3px; } }
     @media (max-width: 380px) {
-      /* line 87, ../scss/components/_soe_brand_bar.scss */
       #header.header #site-title-first-line.site-title-uppercase a {
         font-size: 16px;
         margin-bottom: -4px; } }
 
-/* line 107, ../scss/components/_soe_brand_bar.scss */
 .dm-global-header #header.header #site-title-first-line.site-title-uppercase,
 .dm-global-header #header.header #site-title-first-line.site-title-uppercase a {
   font-size: 18px; }
+
 @media (max-width: 767px) {
-  /* line 113, ../scss/components/_soe_brand_bar.scss */
   .dm-global-header .container {
     margin-bottom: 6px; } }
 
-/* line 8, ../scss/components/_soe_footer.scss */
 #footer.site-footer {
   border-top: none;
   background: #FFFFFF;
   padding: 80px 0; }
-  /* line 13, ../scss/components/_soe_footer.scss */
   #footer.site-footer h2 {
     line-height: 1.3em; }
-/* line 18, ../scss/components/_soe_footer.scss */
+
 #footer .block a.private-link,
 #footer .block .private-link a,
 #footer .block {
   font-size: 1.8rem;
   line-height: 1.3em; }
-  /* line 24, ../scss/components/_soe_footer.scss */
   #footer .block a.private-link p,
   #footer .block .private-link a p,
   #footer .block p {
     margin-bottom: 0.5em; }
+
 @media (max-width: 979px) and (min-width: 767px) {
-  /* line 28, ../scss/components/_soe_footer.scss */
-  #footer .footer-content .block.span2, #footer .footer-content .block.span3, #footer .footer-content .block.span4 {
+  #footer .footer-content .block.span2,
+  #footer .footer-content .block.span3,
+  #footer .footer-content .block.span4 {
     width: 45.6%; } }
 
 @media (max-width: 767px) {
-  /* line 38, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jse-linked-logo-block,
   #footer #block-bean-jumpstart-custom-footer-block {
     margin-bottom: 15px; } }
+
 @media (max-width: 767px) {
-  /* line 45, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-links-footer-block {
     margin-bottom: 0; } }
-/* line 50, ../scss/components/_soe_footer.scss */
+
 #footer #block-bean-jumpstart-links-footer-block a {
   font-weight: 400; }
-/* line 56, ../scss/components/_soe_footer.scss */
+
 #footer #block-bean-jumpstart-custom-footer-block a {
   font-weight: 400; }
-/* line 61, ../scss/components/_soe_footer.scss */
+
 #footer #block-bean-jse-linked-logo-block img {
   max-width: 270px; }
+
 @media (max-width: 979px) {
-  /* line 65, ../scss/components/_soe_footer.scss */
   #footer #block-stanford-soe-helper-sitewide-stanford-soe-intranet-link {
     margin-top: 50px; } }
+
 @media (max-width: 767px) {
-  /* line 65, ../scss/components/_soe_footer.scss */
   #footer #block-stanford-soe-helper-sitewide-stanford-soe-intranet-link {
     margin-top: 0; } }
-/* line 74, ../scss/components/_soe_footer.scss */
+
 #footer #block-bean-jumpstart-footer-social-media-0 {
   float: right;
   width: 22%;
   margin-bottom: 50px; }
   @media (max-width: 1199px) {
-    /* line 74, ../scss/components/_soe_footer.scss */
     #footer #block-bean-jumpstart-footer-social-media-0 {
       width: 24%; } }
   @media (max-width: 979px) {
-    /* line 74, ../scss/components/_soe_footer.scss */
     #footer #block-bean-jumpstart-footer-social-media-0 {
       float: none;
       width: auto;
       margin-bottom: 30px; } }
-  /* line 88, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect a {
     height: 28px;
     background-repeat: no-repeat;
     background-size: auto 28px;
     margin-right: 18px; }
-  /* line 95, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect .field-name-field-s-smc-facebook a {
     background-image: url("../img/soe_facebook_icon.png");
     width: 15px; }
-  /* line 100, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect .field-name-field-s-smc-twitter a {
     background-image: url("../img/soe_twitter_icon.png");
     width: 35px; }
-  /* line 105, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect .field-name-field-s-smc-linkedin a {
     background-image: url("../img/soe_linkedin_icon.png");
     width: 30px; }
-  /* line 110, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect .field-name-field-s-smc-youtube a {
     background-image: url("../img/soe_youtube_icon.png");
     width: 40px; }
-  /* line 115, ../scss/components/_soe_footer.scss */
   #footer #block-bean-jumpstart-footer-social-media-0 .bean-stanford-social-media-connect .field-name-field-s-smc-instagram a {
     background-image: url("../img/soe_instagram_icon.png");
     width: 30px;
     margin-right: 0; }
-/* line 124, ../scss/components/_soe_footer.scss */
+
 #footer #mc_embed_signup_scroll input.button {
   width: 70px; }
+
 @media (max-width: 979px) {
-  /* line 123, ../scss/components/_soe_footer.scss */
   #footer #mc_embed_signup_scroll {
     margin-top: 20px; } }
 
-/* line 10, ../scss/components/_soe_navigation.scss */
 #main-menu .nav-collapse.collapse {
   float: right;
   margin-top: -45px; }
   @media (max-width: 1200px) {
-    /* line 10, ../scss/components/_soe_navigation.scss */
     #main-menu .nav-collapse.collapse {
       float: left;
       margin-top: 0; } }
   @media (max-width: 767px) {
-    /* line 10, ../scss/components/_soe_navigation.scss */
     #main-menu .nav-collapse.collapse {
       width: 100%; } }
+
 @media (max-width: 767px) {
-  /* line 22, ../scss/components/_soe_navigation.scss */
   #main-menu .nav-collapse {
     width: 100%; } }
 
-/* line 29, ../scss/components/_soe_navigation.scss */
 .navbar {
   margin-bottom: 0; }
-  /* line 33, ../scss/components/_soe_navigation.scss */
   .navbar .nav > li > a {
     color: #B1040E;
     font-size: 0.9em;
@@ -758,184 +642,146 @@ p.summary.drop-cap:first-letter {
     border-bottom: 2px solid transparent;
     padding-bottom: 30px; }
     @media (max-width: 767px) {
-      /* line 33, ../scss/components/_soe_navigation.scss */
       .navbar .nav > li > a {
         padding-bottom: 0.25em;
         border-bottom: none; } }
-  /* line 45, ../scss/components/_soe_navigation.scss */
   .navbar .nav > .active > a:hover,
   .navbar .nav > li > a:focus,
   .navbar .nav > li > a:hover,
   .navbar .nav > .active-trail > a {
     border-bottom: 2px solid #333333; }
     @media (max-width: 767px) {
-      /* line 45, ../scss/components/_soe_navigation.scss */
       .navbar .nav > .active > a:hover,
       .navbar .nav > li > a:focus,
       .navbar .nav > li > a:hover,
       .navbar .nav > .active-trail > a {
         border-bottom: none; } }
   @media (max-width: 767px) {
-    /* line 56, ../scss/components/_soe_navigation.scss */
     .navbar .btn.btn-navbar {
       background: #B1040E;
       margin-top: -50px;
       float: right; } }
   @media (max-width: 480px) {
-    /* line 56, ../scss/components/_soe_navigation.scss */
     .navbar .btn.btn-navbar {
       margin-top: -52px; } }
   @media (max-width: 400px) {
-    /* line 56, ../scss/components/_soe_navigation.scss */
     .navbar .btn.btn-navbar {
       margin-top: -37px; } }
   @media (max-width: 320px) {
-    /* line 56, ../scss/components/_soe_navigation.scss */
     .navbar .btn.btn-navbar {
       float: left;
       margin-top: 0; } }
   @media (max-width: 305px) {
-    /* line 56, ../scss/components/_soe_navigation.scss */
     .navbar .btn.btn-navbar {
       float: left;
       margin-top: 0; } }
 
-/* line 79, ../scss/components/_soe_navigation.scss */
 .site-main-menu {
   background: #FFFFFF;
   border-bottom: 1px solid #e1e1e1; }
-  /* line 83, ../scss/components/_soe_navigation.scss */
   .site-main-menu ul li.last.leaf {
     margin-bottom: 0; }
     @media (max-width: 767px) {
-      /* line 83, ../scss/components/_soe_navigation.scss */
       .site-main-menu ul li.last.leaf {
         height: auto;
         border-right: none;
         padding-right: 0; } }
 
-/* line 93, ../scss/components/_soe_navigation.scss */
 .region-navigation .block.contextual-links-region {
   padding-right: 7px;
   margin-right: 7px; }
 
-/* line 101, ../scss/components/_soe_navigation.scss */
 .sidebar .block-menu {
   background: none;
   margin: 1px; }
-  /* line 105, ../scss/components/_soe_navigation.scss */
   .sidebar .block-menu h2 {
     font-family: "Roboto Slab", serif;
     font-weight: 400;
     letter-spacing: 0; }
-  /* line 112, ../scss/components/_soe_navigation.scss */
   .sidebar .block-menu .content > .menu > li.active-trail, .sidebar .block-menu .content > .menu > li.expanded {
     background: none; }
-  /* line 117, ../scss/components/_soe_navigation.scss */
   .sidebar .block-menu .content > .menu > li > a {
     border-top: none;
     padding: 0.5em 0.5em 0.5em 0; }
-    /* line 121, ../scss/components/_soe_navigation.scss */
     .sidebar .block-menu .content > .menu > li > a.active, .sidebar .block-menu .content > .menu > li > a:focus, .sidebar .block-menu .content > .menu > li > a:hover {
       background: none; }
-  /* line 128, ../scss/components/_soe_navigation.scss */
   .sidebar .block-menu .content > .menu > li li a {
     font-size: 0.9em;
     padding: 0.25em; }
-/* line 135, ../scss/components/_soe_navigation.scss */
+
 .sidebar#sidebar-first {
   margin-top: 20px; }
-  /* line 138, ../scss/components/_soe_navigation.scss */
   .sidebar#sidebar-first .block-menu-block {
     background: none;
     margin: 1px 1px 36px;
     padding: 0; }
     @media (max-width: 767px) {
-      /* line 138, ../scss/components/_soe_navigation.scss */
       .sidebar#sidebar-first .block-menu-block {
         width: 100%; } }
-    /* line 146, ../scss/components/_soe_navigation.scss */
     .sidebar#sidebar-first .block-menu-block h2 {
       font-family: "Roboto Slab", serif;
       font-weight: 400;
       letter-spacing: 0; }
     @media (max-width: 767px) {
-      /* line 153, ../scss/components/_soe_navigation.scss */
       .sidebar#sidebar-first .block-menu-block .menu-block-wrapper.menu-block-stanford_jsa_layouts-1.menu-name-main-menu.parent-mlid-0.menu-level-2 {
         background: #FFFFFF;
         padding: 20px;
         box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); } }
-    /* line 163, ../scss/components/_soe_navigation.scss */
     .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li.active-trail {
       background: none; }
-    /* line 167, ../scss/components/_soe_navigation.scss */
     .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li.last {
       border-bottom: none; }
-    /* line 171, ../scss/components/_soe_navigation.scss */
     .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li > a {
       border-top: none;
       font-weight: 600;
       padding: 0.5em 0.5em 0.5em 0; }
-      /* line 176, ../scss/components/_soe_navigation.scss */
       .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li > a.active, .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li > a:focus, .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li > a:hover {
         background: none; }
-    /* line 183, ../scss/components/_soe_navigation.scss */
     .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li li a {
       font-size: 0.9em;
       padding: 0.25em; }
-      /* line 187, ../scss/components/_soe_navigation.scss */
       .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li li a.active-trail, .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li li a:focus, .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li li a:hover {
         text-decoration: none; }
-        /* line 192, ../scss/components/_soe_navigation.scss */
         .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li li a.active-trail:before, .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li li a:focus:before, .sidebar#sidebar-first .block-menu-block .menu-block-wrapper > .menu > li li a:hover:before {
           content: "> ";
           margin-left: -12.5px; }
-    /* line 200, ../scss/components/_soe_navigation.scss */
     .sidebar#sidebar-first .block-menu-block ul.menu li ul {
       padding: 0 0 0 11px; }
-    /* line 204, ../scss/components/_soe_navigation.scss */
     .sidebar#sidebar-first .block-menu-block .content > .menu > li.expanded {
       background: none; }
-/* line 210, ../scss/components/_soe_navigation.scss */
+
 .sidebar .nav li a {
   color: #B1040E; }
 
-/* line 215, ../scss/components/_soe_navigation.scss */
 .main .menu li {
   line-height: 1.2em; }
 
-/* line 10, ../scss/components/_soe_images.scss */
 .main .border-simple img,
 .main .border-simple-nowidth img {
   padding: 0; }
-/* line 15, ../scss/components/_soe_images.scss */
+
 .main .border-shadow img {
   box-shadow: none; }
 
-/* line 20, ../scss/components/_soe_images.scss */
 .postcard-left > div:first-child img,
 .postcard-left-wrap > div:first-child img {
   margin-top: 7px; }
 
 @media (max-width: 550px) {
-  /* line 25, ../scss/components/_soe_images.scss */
   .node-stanford-landing-page.large-landscape .field-name-field-landing-page-item > .field-items > .field-item img {
     width: 100%;
     margin-right: 0; } }
 
 @media (max-width: 400px) {
-  /* line 32, ../scss/components/_soe_images.scss */
   .node .group_s_postcard_image {
     max-width: 100%;
     float: none; } }
 
-/* line 42, ../scss/components/_soe_images.scss */
 #block-views-stanford-page-top-banner-block .page-feat-image-container {
   background: #333333; }
-  /* line 44, ../scss/components/_soe_images.scss */
   #block-views-stanford-page-top-banner-block .page-feat-image-container img {
     width: 100%; }
-/* line 49, ../scss/components/_soe_images.scss */
+
 #block-views-stanford-page-top-banner-block .page-feat-scroll-container {
   color: #FFFFFF;
   background: -webkit-linear-gradient(top, transparent 0%, rgba(0, 0, 0, 0.7) 100%);
@@ -949,40 +795,33 @@ p.summary.drop-cap:first-letter {
   text-align: center;
   width: 100%;
   height: 200px; }
-  /* line 58, ../scss/components/_soe_images.scss */
   #block-views-stanford-page-top-banner-block .page-feat-scroll-container p {
     position: absolute;
     bottom: 55px;
     width: 100%;
     margin-bottom: 0; }
-  /* line 65, ../scss/components/_soe_images.scss */
   #block-views-stanford-page-top-banner-block .page-feat-scroll-container:after {
     content: url("../img/soe_chevron_down_white.png");
     position: absolute;
     bottom: 20px; }
 
-/* line 76, ../scss/components/_soe_images.scss */
 .view-stanford-page-banner-caption .views-row {
   margin-bottom: 0; }
-/* line 80, ../scss/components/_soe_images.scss */
+
 .view-stanford-page-banner-caption .banner-bottom-container {
   position: relative;
   overflow: hidden; }
   @media (max-width: 767px) {
-    /* line 80, ../scss/components/_soe_images.scss */
     .view-stanford-page-banner-caption .banner-bottom-container {
       position: inherit; } }
-  /* line 87, ../scss/components/_soe_images.scss */
   .view-stanford-page-banner-caption .banner-bottom-container img {
     width: 100%;
     -webkit-transition: all 1s ease;
     -moz-transition: all 1s ease;
     -o-transition: all 1s ease;
     transition: all 1s ease; }
-  /* line 92, ../scss/components/_soe_images.scss */
   .view-stanford-page-banner-caption .banner-bottom-container .more-link {
     font-size: 1em; }
-    /* line 95, ../scss/components/_soe_images.scss */
     .view-stanford-page-banner-caption .banner-bottom-container .more-link a {
       color: #000000;
       font-family: "Roboto Slab", serif;
@@ -990,18 +829,14 @@ p.summary.drop-cap:first-letter {
       font-weight: 800;
       line-height: 1.2em; }
       @media (max-width: 1200px) {
-        /* line 95, ../scss/components/_soe_images.scss */
         .view-stanford-page-banner-caption .banner-bottom-container .more-link a {
           font-size: 1.3em; } }
       @media (max-width: 979px) {
-        /* line 95, ../scss/components/_soe_images.scss */
         .view-stanford-page-banner-caption .banner-bottom-container .more-link a {
           font-size: 1.2em; } }
       @media (max-width: 767px) {
-        /* line 95, ../scss/components/_soe_images.scss */
         .view-stanford-page-banner-caption .banner-bottom-container .more-link a {
           font-size: 1.1em; } }
-      /* line 111, ../scss/components/_soe_images.scss */
       .view-stanford-page-banner-caption .banner-bottom-container .more-link a:after {
         content: "";
         background-image: url("../img/soe_lg_arrow_right_black.svg");
@@ -1011,84 +846,66 @@ p.summary.drop-cap:first-letter {
         padding-left: 41px;
         margin-left: 12px; }
         @media (max-width: 979px) {
-          /* line 111, ../scss/components/_soe_images.scss */
           .view-stanford-page-banner-caption .banner-bottom-container .more-link a:after {
             background-size: 31px 23px;
             vertical-align: -16%;
             padding-left: 31px; } }
         @media (max-width: 767px) {
-          /* line 111, ../scss/components/_soe_images.scss */
           .view-stanford-page-banner-caption .banner-bottom-container .more-link a:after {
             background-size: 28px 20px;
             padding-left: 28px; } }
         @media (max-width: 480px) {
-          /* line 111, ../scss/components/_soe_images.scss */
           .view-stanford-page-banner-caption .banner-bottom-container .more-link a:after {
             vertical-align: -19%; } }
-  /* line 136, ../scss/components/_soe_images.scss */
   .view-stanford-page-banner-caption .banner-bottom-container:hover img {
     -webkit-transform: scale(1.03);
     -moz-transform: scale(1.03);
     -o-transform: scale(1.03);
     transform: scale(1.03); }
-  /* line 140, ../scss/components/_soe_images.scss */
   .view-stanford-page-banner-caption .banner-bottom-container:hover .more-link a {
     text-decoration: underline; }
-/* line 146, ../scss/components/_soe_images.scss */
+
 .view-stanford-page-banner-caption div.more-link {
   padding: 18px 32px 20px;
   margin: 0; }
   @media (max-width: 767px) {
-    /* line 146, ../scss/components/_soe_images.scss */
     .view-stanford-page-banner-caption div.more-link {
       width: 100%; } }
   @media (max-width: 480px) {
-    /* line 146, ../scss/components/_soe_images.scss */
     .view-stanford-page-banner-caption div.more-link {
       width: 87%; } }
-/* line 157, ../scss/components/_soe_images.scss */
+
 .view-stanford-page-banner-caption .banner-caption {
   position: absolute;
   width: 80%; }
   @media (max-width: 767px) {
-    /* line 157, ../scss/components/_soe_images.scss */
     .view-stanford-page-banner-caption .banner-caption {
       position: inherit;
       width: 92%; } }
   @media (max-width: 480px) {
-    /* line 157, ../scss/components/_soe_images.scss */
     .view-stanford-page-banner-caption .banner-caption {
       width: 100%; } }
-  /* line 168, ../scss/components/_soe_images.scss */
   .view-stanford-page-banner-caption .banner-caption.banner-right {
     right: 0;
     text-align: right; }
     @media (max-width: 767px) {
-      /* line 168, ../scss/components/_soe_images.scss */
       .view-stanford-page-banner-caption .banner-caption.banner-right {
         text-align: left; } }
-    /* line 175, ../scss/components/_soe_images.scss */
     .view-stanford-page-banner-caption .banner-caption.banner-right.banner-bottom {
       bottom: 40px; }
-    /* line 179, ../scss/components/_soe_images.scss */
     .view-stanford-page-banner-caption .banner-caption.banner-right.banner-top {
       top: 40px; }
-  /* line 184, ../scss/components/_soe_images.scss */
   .view-stanford-page-banner-caption .banner-caption.banner-orange div.more-link {
     background: #FFBD54; }
-  /* line 188, ../scss/components/_soe_images.scss */
   .view-stanford-page-banner-caption .banner-caption.banner-turquoise div.more-link {
     background: #00ECE9; }
-  /* line 192, ../scss/components/_soe_images.scss */
   .view-stanford-page-banner-caption .banner-caption.banner-pink div.more-link {
     background: #FF525C; }
 
 @media (max-width: 767px) {
-  /* line 201, ../scss/components/_soe_images.scss */
   .view-soe-opportunity-grid .views-row img {
     width: 100%; } }
 
-/* line 11, ../scss/components/_soe_page_layout.scss */
 .node-type-stanford-landing-page .header-370x170 .postcard-linked-container {
   display: flex;
   background: #FFFFFF;
@@ -1098,64 +915,50 @@ p.summary.drop-cap:first-letter {
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
   @media (max-width: 767px) {
-    /* line 11, ../scss/components/_soe_page_layout.scss */
     .node-type-stanford-landing-page .header-370x170 .postcard-linked-container {
       display: block; } }
-  /* line 21, ../scss/components/_soe_page_layout.scss */
   .node-type-stanford-landing-page .header-370x170 .postcard-linked-container a.postcard-linked-img-container {
     flex-shrink: 0;
     margin-right: 30px; }
     @media (max-width: 767px) {
-      /* line 21, ../scss/components/_soe_page_layout.scss */
       .node-type-stanford-landing-page .header-370x170 .postcard-linked-container a.postcard-linked-img-container {
         margin-right: 0; } }
-    /* line 28, ../scss/components/_soe_page_layout.scss */
     .node-type-stanford-landing-page .header-370x170 .postcard-linked-container a.postcard-linked-img-container:hover img {
       -webkit-transform: scale(1.03);
       -moz-transform: scale(1.03);
       -o-transform: scale(1.03);
       transform: scale(1.03); }
-    /* line 32, ../scss/components/_soe_page_layout.scss */
     .node-type-stanford-landing-page .header-370x170 .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img {
       position: relative; }
-      /* line 35, ../scss/components/_soe_page_layout.scss */
       .node-type-stanford-landing-page .header-370x170 .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-lp-item-image {
         overflow: hidden; }
-        /* line 38, ../scss/components/_soe_page_layout.scss */
         .node-type-stanford-landing-page .header-370x170 .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-lp-item-image img {
           -webkit-transition: all 1s ease;
           -moz-transition: all 1s ease;
           -o-transition: all 1s ease;
           transition: all 1s ease; }
           @media (max-width: 767px) {
-            /* line 38, ../scss/components/_soe_page_layout.scss */
             .node-type-stanford-landing-page .header-370x170 .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-lp-item-image img {
               width: 100%; } }
-      /* line 46, ../scss/components/_soe_page_layout.scss */
       .node-type-stanford-landing-page .header-370x170 .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow {
         position: absolute;
         bottom: 20px;
         right: 20px;
         width: 40px;
         height: 40px; }
-        /* line 53, ../scss/components/_soe_page_layout.scss */
         .node-type-stanford-landing-page .header-370x170 .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img {
           width: 26px;
           height: auto;
           vertical-align: -9px;
           padding: 3px 8px; }
           @media (max-width: 767px) {
-            /* line 53, ../scss/components/_soe_page_layout.scss */
             .node-type-stanford-landing-page .header-370x170 .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img {
               vertical-align: -12px; } }
           @media (max-width: 480px) {
-            /* line 53, ../scss/components/_soe_page_layout.scss */
             .node-type-stanford-landing-page .header-370x170 .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img {
               vertical-align: -14px; } }
-  /* line 69, ../scss/components/_soe_page_layout.scss */
   .node-type-stanford-landing-page .header-370x170 .postcard-linked-container .postcard-linked-content-container {
     width: 100%; }
-    /* line 72, ../scss/components/_soe_page_layout.scss */
     .node-type-stanford-landing-page .header-370x170 .postcard-linked-container .postcard-linked-content-container a.postcard-linked-title {
       color: #333333;
       font-family: "Roboto Slab", serif;
@@ -1168,113 +971,99 @@ p.summary.drop-cap:first-letter {
       -webkit-text-decoration-color: #00ECE9;
       text-decoration-color: #00ECE9; }
       @media (max-width: 767px) {
-        /* line 72, ../scss/components/_soe_page_layout.scss */
         .node-type-stanford-landing-page .header-370x170 .postcard-linked-container .postcard-linked-content-container a.postcard-linked-title {
           margin-top: 20px; } }
-      /* line 85, ../scss/components/_soe_page_layout.scss */
       .node-type-stanford-landing-page .header-370x170 .postcard-linked-container .postcard-linked-content-container a.postcard-linked-title:focus, .node-type-stanford-landing-page .header-370x170 .postcard-linked-container .postcard-linked-content-container a.postcard-linked-title:hover {
         -webkit-text-decoration-color: #333333;
         text-decoration-color: #333333; }
-/* line 93, ../scss/components/_soe_page_layout.scss */
+
 .node-type-stanford-landing-page .header-370x170 .postcard-linked-arrow-color-orange .postcard-linked-arrow {
   background: #FFBD54; }
-/* line 97, ../scss/components/_soe_page_layout.scss */
+
 .node-type-stanford-landing-page .header-370x170 .postcard-linked-arrow-color-turquoise .postcard-linked-arrow {
   background: #00ECE9; }
-/* line 101, ../scss/components/_soe_page_layout.scss */
+
 .node-type-stanford-landing-page .header-370x170 .postcard-linked-arrow-color-pink .postcard-linked-arrow {
   background: #FF525C; }
+
 @media (max-width: 1200px) {
-  /* line 106, ../scss/components/_soe_page_layout.scss */
   .node-type-stanford-landing-page.stanford-4-col-header .field-name-field-landing-page-item > .field-items > .field-item {
     width: 46.333%; } }
+
 @media (max-width: 979px) {
-  /* line 106, ../scss/components/_soe_page_layout.scss */
   .node-type-stanford-landing-page.stanford-4-col-header .field-name-field-landing-page-item > .field-items > .field-item {
     width: 48%;
     margin-right: 1.5%; } }
+
 @media (max-width: 525px) {
-  /* line 106, ../scss/components/_soe_page_layout.scss */
   .node-type-stanford-landing-page.stanford-4-col-header .field-name-field-landing-page-item > .field-items > .field-item {
     width: 100%;
     max-width: 100%;
     margin-right: 0; } }
+
 @media (max-width: 979px) {
-  /* line 121, ../scss/components/_soe_page_layout.scss */
   .node-type-stanford-landing-page.large-landscape .field-name-field-landing-page-item > .field-items > .field-item {
     width: 48%; }
-    /* line 125, ../scss/components/_soe_page_layout.scss */
     .node-type-stanford-landing-page.large-landscape .field-name-field-landing-page-item > .field-items > .field-item:nth-child(3n) {
       margin-right: 3%; }
-    /* line 129, ../scss/components/_soe_page_layout.scss */
     .node-type-stanford-landing-page.large-landscape .field-name-field-landing-page-item > .field-items > .field-item:nth-child(2n) {
       margin-right: 0; } }
+
 @media (max-width: 550px) {
-  /* line 121, ../scss/components/_soe_page_layout.scss */
   .node-type-stanford-landing-page.large-landscape .field-name-field-landing-page-item > .field-items > .field-item {
     width: 100%;
     margin-right: 0; }
-    /* line 137, ../scss/components/_soe_page_layout.scss */
     .node-type-stanford-landing-page.large-landscape .field-name-field-landing-page-item > .field-items > .field-item:nth-child(3n) {
       margin-right: 0; } }
-/* line 143, ../scss/components/_soe_page_layout.scss */
+
 .node-type-stanford-landing-page .view-stanford-person-grid .views-row h3 {
   font-size: 1em;
   margin: 0.6em 0 0; }
-/* line 148, ../scss/components/_soe_page_layout.scss */
+
 .node-type-stanford-landing-page .view-mode-stanford_medium_square {
   border-top: 1px solid #D7D7D7; }
 
 @media (min-width: 767px) {
-  /* line 155, ../scss/components/_soe_page_layout.scss */
   .views-grid-two .views-row {
     width: 46%;
     margin-right: 7%; } }
 
-/* line 163, ../scss/components/_soe_page_layout.scss */
 .view-stanford-person-grid .views-row h3 {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 20px;
   margin: .3em 0 0; }
-  /* line 167, ../scss/components/_soe_page_layout.scss */
   .view-stanford-person-grid .views-row h3 a {
     text-decoration: none; }
-/* line 171, ../scss/components/_soe_page_layout.scss */
+
 .view-stanford-person-grid .views-row div.field-content {
   line-height: 1.3em;
   font-size: 18px; }
 
 @media (min-width: 1200px) {
-  /* line 179, ../scss/components/_soe_page_layout.scss */
   .row-fluid .span6 {
     width: 46.5%;
     margin-left: 7%; } }
+
 @media (min-width: 1200px) {
-  /* line 185, ../scss/components/_soe_page_layout.scss */
   .row-fluid .span6.next-row {
     margin-left: 0; } }
 
-/* line 194, ../scss/components/_soe_page_layout.scss */
 .node .group_s_postcard_image .field-collection-container > .field > .field-items > .field-item {
   margin-left: 2em; }
   @media (max-width: 400px) {
-    /* line 194, ../scss/components/_soe_page_layout.scss */
     .node .group_s_postcard_image .field-collection-container > .field > .field-items > .field-item {
       margin-left: 0; } }
 
-/* line 8, ../scss/components/_soe_homepage.scss */
 .front .main {
   padding: 0; }
-/* line 13, ../scss/components/_soe_homepage.scss */
+
 .front [id*="block-bean-homepage-2-column-"] .content {
   width: 85%;
   margin: 0 auto 50px; }
   @media (max-width: 767px) {
-    /* line 13, ../scss/components/_soe_homepage.scss */
     .front [id*="block-bean-homepage-2-column-"] .content {
       margin-bottom: 20px;
       width: 95%; } }
-  /* line 21, ../scss/components/_soe_homepage.scss */
   .front [id*="block-bean-homepage-2-column-"] .content a:not(.btn) {
     color: #333333;
     text-decoration: underline;
@@ -1282,122 +1071,106 @@ p.summary.drop-cap:first-letter {
     text-decoration-skip: ink;
     -webkit-text-decoration-color: #00ECE9;
     text-decoration-color: #00ECE9; }
-    /* line 27, ../scss/components/_soe_homepage.scss */
     .front [id*="block-bean-homepage-2-column-"] .content a:not(.btn):focus, .front [id*="block-bean-homepage-2-column-"] .content a:not(.btn):hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
-  /* line 33, ../scss/components/_soe_homepage.scss */
   .front [id*="block-bean-homepage-2-column-"] .content p.columns {
     margin-bottom: 50px; }
     @media (max-width: 767px) {
-      /* line 33, ../scss/components/_soe_homepage.scss */
       .front [id*="block-bean-homepage-2-column-"] .content p.columns {
         margin-top: -36px;
         margin-bottom: 30px; } }
     @media (max-width: 580px) {
-      /* line 33, ../scss/components/_soe_homepage.scss */
       .front [id*="block-bean-homepage-2-column-"] .content p.columns {
         font-size: 1.1em; } }
     @media (max-width: 480px) {
-      /* line 33, ../scss/components/_soe_homepage.scss */
       .front [id*="block-bean-homepage-2-column-"] .content p.columns {
         line-height: 1.5em; } }
-/* line 51, ../scss/components/_soe_homepage.scss */
+
 .front .bean-stanford-postcard-linked .postcard-linked-container,
 .front .view-stanford-page-banner-caption {
   margin-bottom: 100px; }
   @media (max-width: 767px) {
-    /* line 51, ../scss/components/_soe_homepage.scss */
     .front .bean-stanford-postcard-linked .postcard-linked-container,
     .front .view-stanford-page-banner-caption {
       margin-bottom: 30px; } }
-/* line 60, ../scss/components/_soe_homepage.scss */
+
 .front .view-stanford-ppl-spot-fw-banner-quote {
   margin-bottom: 60px; }
-/* line 64, ../scss/components/_soe_homepage.scss */
+
 .front #block-bean-homepage-magazine-postcard-butto {
   margin: 80px 0 60px; }
-/* line 68, ../scss/components/_soe_homepage.scss */
+
 .front #block-bean-stanford-soe-mailchimp-homepage- {
   margin-bottom: 80px; }
-/* line 72, ../scss/components/_soe_homepage.scss */
+
 .front .mailchimp-magazine-block #mc_embed_signup_scroll {
   padding: 50px; }
-  /* line 75, ../scss/components/_soe_homepage.scss */
   .front .mailchimp-magazine-block #mc_embed_signup_scroll h2 {
     margin-bottom: 0; }
-  /* line 79, ../scss/components/_soe_homepage.scss */
   .front .mailchimp-magazine-block #mc_embed_signup_scroll p {
     margin-bottom: 1.8em; }
-/* line 85, ../scss/components/_soe_homepage.scss */
+
 .front [id*="block-bean-homepage-pl-block-1"],
 .front [id*="block-views-0969cf96ba3c89e5f5ea0784f69f7372"] {
   margin-left: 12.75%; }
   @media (max-width: 767px) {
-    /* line 85, ../scss/components/_soe_homepage.scss */
     .front [id*="block-bean-homepage-pl-block-1"],
     .front [id*="block-views-0969cf96ba3c89e5f5ea0784f69f7372"] {
       margin-left: 0;
       margin: 0 auto;
       width: 95%; } }
+
 @media (max-width: 767px) {
-  /* line 95, ../scss/components/_soe_homepage.scss */
   .front [id*="block-bean-homepage-pl-block-2"],
   .front .view-stanford-news-featured {
     margin: 0 auto;
     width: 95%; } }
-/* line 103, ../scss/components/_soe_homepage.scss */
+
 .front [id*="block-bean-homepage-pl-block-3"],
 .front [id*="block-views-stanford-event-featured-block-1"] {
   margin-right: 12.75%; }
   @media (max-width: 767px) {
-    /* line 103, ../scss/components/_soe_homepage.scss */
     .front [id*="block-bean-homepage-pl-block-3"],
     .front [id*="block-views-stanford-event-featured-block-1"] {
       margin-right: 0;
       margin: 0 auto;
       width: 95%; } }
+
 @media (max-width: 580px) {
-  /* line 113, ../scss/components/_soe_homepage.scss */
   .front [id*="block-bean-homepage-magazine-postcard-butto"] {
     margin: 30px 0 30px; } }
 
-/* line 8, ../scss/components/_soe_calendar.scss */
 .calendar-calendar .mini td,
 .calendar-calendar th.days {
   background: #EFEFEF; }
-/* line 13, ../scss/components/_soe_calendar.scss */
+
 .calendar-calendar .mini td.has-events,
 .calendar-calendar table.mini td.empty {
   background: #D7D7D7; }
 
-/* line 19, ../scss/components/_soe_calendar.scss */
 .date-stacked {
   margin-top: 7px;
   background: #333333;
   padding: 8px 12px 10px; }
-  /* line 24, ../scss/components/_soe_calendar.scss */
   .date-stacked .date-month {
     font-weight: 100;
     line-height: 16px; }
-  /* line 29, ../scss/components/_soe_calendar.scss */
   .date-stacked .date-day {
     font-size: 1.1em;
     font-family: "Roboto Slab", serif;
     font-weight: 400; }
 
-/* line 36, ../scss/components/_soe_calendar.scss */
 .view-stanford-events-calendar .view-header .date-nav-wrapper {
   background: #FFFFFF; }
 
-/* line 10, ../scss/components/_soe_forms.scss */
 body:not(.page-admin) button,
 body:not(.page-admin) input,
 body:not(.page-admin) label,
 body:not(.page-admin) select,
 body:not(.page-admin) textarea {
   font-size: 0.8em; }
-/* line 18, ../scss/components/_soe_forms.scss */
+
 body:not(.page-admin) .uneditable-input,
 body:not(.page-admin) input[type="color"],
 body:not(.page-admin) input[type="date"],
@@ -1416,54 +1189,49 @@ body:not(.page-admin) input[type="week"],
 body:not(.page-admin) textarea {
   height: 30px;
   padding: 4px 13px 7px; }
-/* line 38, ../scss/components/_soe_forms.scss */
+
 body:not(.page-admin) input[type="file"],
 body:not(.page-admin) select {
   height: 40px; }
-/* line 43, ../scss/components/_soe_forms.scss */
+
 body:not(.page-admin) .uneditable-input,
 body:not(.page-admin) input,
 body:not(.page-admin) textarea {
   width: 178px; }
-/* line 49, ../scss/components/_soe_forms.scss */
+
 body:not(.page-admin) .form-item label {
   font-weight: 400; }
-/* line 53, ../scss/components/_soe_forms.scss */
+
 body:not(.page-admin) input.form-submit {
   padding: 0 13px;
   background-image: none;
   background: #FFFFFF;
   color: #8c1515; }
-  /* line 59, ../scss/components/_soe_forms.scss */
   body:not(.page-admin) input.form-submit:focus, body:not(.page-admin) input.form-submit:hover {
     background: #B1040E;
     color: #FFFFFF; }
-/* line 67, ../scss/components/_soe_forms.scss */
+
 body:not(.page-admin) .views-exposed-form label {
   font-weight: normal; }
-/* line 71, ../scss/components/_soe_forms.scss */
+
 body:not(.page-admin) .views-exposed-form .views-exposed-widget {
   padding: 0.8em 0.7em 0 0; }
-/* line 76, ../scss/components/_soe_forms.scss */
+
 body:not(.page-admin) .node-type-webform textarea {
   height: 100px; }
-/* line 80, ../scss/components/_soe_forms.scss */
+
 body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-submit {
   margin-top: 1em; }
 
-/* line 88, ../scss/components/_soe_forms.scss */
 #mc_embed_signup_scroll .mc-field-group {
   float: left; }
-  /* line 91, ../scss/components/_soe_forms.scss */
   #mc_embed_signup_scroll .mc-field-group input {
     border-radius: 0; }
-  /* line 95, ../scss/components/_soe_forms.scss */
   #mc_embed_signup_scroll .mc-field-group input::-webkit-input-placeholder {
     color: #CCCCCC; }
-  /* line 99, ../scss/components/_soe_forms.scss */
   #mc_embed_signup_scroll .mc-field-group input::-moz-placeholder {
     color: #CCCCCC; }
-/* line 105, ../scss/components/_soe_forms.scss */
+
 #mc_embed_signup_scroll #mc-embedded-subscribe.button,
 #mc_embed_signup_scroll #mc-embedded-subscribe input {
   background-color: #B1040E;
@@ -1471,34 +1239,33 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   color: #FFFFFF;
   margin-left: 0.7em; }
   @media (max-width: 767px) {
-    /* line 105, ../scss/components/_soe_forms.scss */
     #mc_embed_signup_scroll #mc-embedded-subscribe.button,
     #mc_embed_signup_scroll #mc-embedded-subscribe input {
       margin-left: 0.4em; } }
-/* line 116, ../scss/components/_soe_forms.scss */
+
 #mc_embed_signup_scroll #mc-embedded-subscribe.button:focus, #mc_embed_signup_scroll #mc-embedded-subscribe.button:hover {
   background-color: #333333; }
-/* line 122, ../scss/components/_soe_forms.scss */
+
 #mc_embed_signup_scroll p {
   padding-right: 10px; }
-/* line 126, ../scss/components/_soe_forms.scss */
+
 #mc_embed_signup_scroll input.button {
   height: 43px;
   padding: 0 13px 3px;
   -webkit-border-radius: 0;
   width: 76px; }
-/* line 133, ../scss/components/_soe_forms.scss */
+
 #mc_embed_signup_scroll .uneditable-input,
 #mc_embed_signup_scroll input,
 #mc_embed_signup_scroll textarea {
   width: 110px; }
-/* line 139, ../scss/components/_soe_forms.scss */
+
 #mc_embed_signup_scroll button,
 #mc_embed_signup_scroll input,
 #mc_embed_signup_scroll select,
 #mc_embed_signup_scroll textarea {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif; }
-/* line 146, ../scss/components/_soe_forms.scss */
+
 .mailchimp-magazine-block #mc_embed_signup_scroll {
   background: #FFFFFF;
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
@@ -1506,56 +1273,46 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   padding: 35px;
   text-align: center; }
-  /* line 152, ../scss/components/_soe_forms.scss */
   .mailchimp-magazine-block #mc_embed_signup_scroll p {
     line-height: 1.3em;
     margin-top: 10px; }
-  /* line 157, ../scss/components/_soe_forms.scss */
   .mailchimp-magazine-block #mc_embed_signup_scroll form {
     margin-bottom: 0; }
-  /* line 161, ../scss/components/_soe_forms.scss */
   .mailchimp-magazine-block #mc_embed_signup_scroll h2 {
     margin-bottom: 25px; }
-  /* line 165, ../scss/components/_soe_forms.scss */
   .mailchimp-magazine-block #mc_embed_signup_scroll .mc_signup_submission_wrapper {
     display: flex;
     justify-content: center; }
-  /* line 170, ../scss/components/_soe_forms.scss */
   .mailchimp-magazine-block #mc_embed_signup_scroll .mc-field-group {
     float: none; }
-    /* line 173, ../scss/components/_soe_forms.scss */
     .mailchimp-magazine-block #mc_embed_signup_scroll .mc-field-group input {
       width: 400px;
       box-shadow: none; }
       @media (max-width: 767px) {
-        /* line 173, ../scss/components/_soe_forms.scss */
         .mailchimp-magazine-block #mc_embed_signup_scroll .mc-field-group input {
           width: 200px; } }
-  /* line 182, ../scss/components/_soe_forms.scss */
-  .page-magazine .mailchimp-magazine-block #mc_embed_signup_scroll, .page-magazine-all .mailchimp-magazine-block #mc_embed_signup_scroll, .page-taxonomy-term .mailchimp-magazine-block #mc_embed_signup_scroll {
+  .page-magazine .mailchimp-magazine-block #mc_embed_signup_scroll,
+  .page-magazine-all .mailchimp-magazine-block #mc_embed_signup_scroll,
+  .page-taxonomy-term .mailchimp-magazine-block #mc_embed_signup_scroll {
     margin-bottom: 80px;
     padding: 65px 0;
     box-shadow: none; }
     @media (max-width: 480px) {
-      /* line 182, ../scss/components/_soe_forms.scss */
-      .page-magazine .mailchimp-magazine-block #mc_embed_signup_scroll, .page-magazine-all .mailchimp-magazine-block #mc_embed_signup_scroll, .page-taxonomy-term .mailchimp-magazine-block #mc_embed_signup_scroll {
+      .page-magazine .mailchimp-magazine-block #mc_embed_signup_scroll,
+      .page-magazine-all .mailchimp-magazine-block #mc_embed_signup_scroll,
+      .page-taxonomy-term .mailchimp-magazine-block #mc_embed_signup_scroll {
         margin-bottom: 20px; } }
-  /* line 193, ../scss/components/_soe_forms.scss */
   .node-type-stanford-magazine-issue .mailchimp-magazine-block #mc_embed_signup_scroll {
     box-shadow: none;
     padding: 65px 0; }
 
-/* line 200, ../scss/components/_soe_forms.scss */
 .node-type-stanford-magazine-issue .mailchimp-magazine-block form {
   margin-bottom: 0; }
 
-/* line 8, ../scss/components/_soe_search.scss */
 #global-header .block-stanford-search-api {
   margin-top: -22px; }
-  /* line 11, ../scss/components/_soe_search.scss */
   #global-header .block-stanford-search-api input#edit-search {
     display: none; }
-  /* line 15, ../scss/components/_soe_search.scss */
   #global-header .block-stanford-search-api input[type="text"] {
     font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 16px;
@@ -1569,146 +1326,124 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     -moz-transition: width 1s ease;
     -o-transition: width 1s ease;
     transition: width 1s ease; }
-    /* line 26, ../scss/components/_soe_search.scss */
     .not-logged-in #global-header .block-stanford-search-api input[type="text"] {
       margin-right: -15px; }
-    /* line 30, ../scss/components/_soe_search.scss */
     #global-header .block-stanford-search-api input[type="text"]:focus {
       background-position-x: 0;
       margin-right: 0; }
-  /* line 36, ../scss/components/_soe_search.scss */
   #global-header .block-stanford-search-api .input-medium {
     width: 60px; }
-    /* line 39, ../scss/components/_soe_search.scss */
     #global-header .block-stanford-search-api .input-medium:focus {
       width: 175px; }
       @media (max-width: 480px) {
-        /* line 39, ../scss/components/_soe_search.scss */
         #global-header .block-stanford-search-api .input-medium:focus {
           width: 170px; } }
-  /* line 47, ../scss/components/_soe_search.scss */
   #global-header .block-stanford-search-api input:-ms-input-placeholder {
     color: #FFFFFF; }
-  /* line 51, ../scss/components/_soe_search.scss */
   #global-header .block-stanford-search-api input::-moz-placeholder {
     color: #FFFFFF; }
-  /* line 55, ../scss/components/_soe_search.scss */
   #global-header .block-stanford-search-api input::-webkit-input-placeholder {
     color: #FFFFFF; }
 
-/* line 61, ../scss/components/_soe_search.scss */
 .page-search div#edit-basic {
   margin-bottom: 5px; }
 
-/* line 66, ../scss/components/_soe_search.scss */
 .search-views-left h2 a {
   text-decoration: underline;
   -webkit-text-decoration-color: #00ECE9;
   text-decoration-color: #00ECE9; }
-/* line 71, ../scss/components/_soe_search.scss */
+
 .search-views-left:hover, .search-views-leftfocus {
   color: #606060;
   text-decoration: underline;
   -webkit-text-decoration-color: #606060;
   text-decoration-color: #606060; }
 
-/* line 13, ../scss/components/_soe_news.scss */
 .node-type-stanford-news-item .date-display-single {
   font-weight: 600; }
-/* line 17, ../scss/components/_soe_news.scss */
+
 .node-type-stanford-news-item #page-title {
   display: none; }
-/* line 21, ../scss/components/_soe_news.scss */
+
 .node-type-stanford-news-item div#content-head {
   margin-bottom: 0; }
-/* line 25, ../scss/components/_soe_news.scss */
+
 .node-type-stanford-news-item .body-style {
   width: 750px; }
+
 @media (min-width: 979px) {
-  /* line 32, ../scss/components/_soe_news.scss */
   .node-type-stanford-news-item .postcard-image {
     width: 850px; } }
-/* line 39, ../scss/components/_soe_news.scss */
+
 .node-type-stanford-news-item .fullwidth .field-name-field-s-news-banner .field-item {
   background: #333333; }
-/* line 43, ../scss/components/_soe_news.scss */
+
 .node-type-stanford-news-item .fullwidth .field-name-field-s-news-banner img {
   width: 100%;
   height: 360px;
   opacity: 0.4; }
-/* line 65, ../scss/components/_soe_news.scss */
+
 .node-type-stanford-news-item .content-body .field-name-field-s-image-image {
   margin-bottom: 0; }
-/* line 69, ../scss/components/_soe_news.scss */
+
 .node-type-stanford-news-item .content-body .group-s-news-body-style {
   margin-top: 1em; }
-/* line 74, ../scss/components/_soe_news.scss */
+
 .node-type-stanford-news-item .caption {
   font-size: 0.7em;
   font-style: normal; }
-  /* line 78, ../scss/components/_soe_news.scss */
   .node-type-stanford-news-item .caption p:after {
     padding-right: 3px; }
-/* line 83, ../scss/components/_soe_news.scss */
+
 .node-type-stanford-news-item .credits {
   margin-bottom: 0;
   margin-top: -8px;
   color: #606060;
   font-size: 0.7em; }
-/* line 90, ../scss/components/_soe_news.scss */
+
 .node-type-stanford-news-item .group-s-news-byline-style.credits,
 .node-type-stanford-news-item .group-s-news-date-style.credits {
   color: #333333;
   font-size: 1em;
   line-height: 1.5em; }
+
 @media (max-width: 550px) {
-  /* line 97, ../scss/components/_soe_news.scss */
   .node-type-stanford-news-item .group-s-caption-style.field-group-div.caption,
   .node-type-stanford-news-item .group-s-credits-style.field-group-div.credits {
     display: block; } }
 
-/* line 105, ../scss/components/_soe_news.scss */
 #block-ds-extras-banner-overlay {
   width: 750px;
   position: absolute;
   top: 210px; }
   @media (max-width: 1200px) {
-    /* line 105, ../scss/components/_soe_news.scss */
     #block-ds-extras-banner-overlay {
       top: 250px; } }
   @media (max-width: 767px) {
-    /* line 105, ../scss/components/_soe_news.scss */
     #block-ds-extras-banner-overlay {
       position: relative;
       top: -196px;
       margin-bottom: -245px; } }
   @media (max-width: 580px) {
-    /* line 105, ../scss/components/_soe_news.scss */
     #block-ds-extras-banner-overlay {
       top: -224px; } }
   @media (max-width: 480px) {
-    /* line 105, ../scss/components/_soe_news.scss */
     #block-ds-extras-banner-overlay {
       width: 100%; } }
   @media (max-width: 380px) {
-    /* line 105, ../scss/components/_soe_news.scss */
     #block-ds-extras-banner-overlay {
       top: -315px;
       width: 250px; } }
-  /* line 132, ../scss/components/_soe_news.scss */
   #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
     color: #FFFFFF;
     text-shadow: 0 0 4px #000000;
     line-height: 1.3em; }
     @media (max-width: 485px) {
-      /* line 132, ../scss/components/_soe_news.scss */
       #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
         font-size: 0.75em; } }
     @media (max-width: 380px) {
-      /* line 132, ../scss/components/_soe_news.scss */
       #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
         font-size: 0.7em; } }
-  /* line 147, ../scss/components/_soe_news.scss */
   #block-ds-extras-banner-overlay .field-name-title h1 {
     color: #FFFFFF;
     font-size: 2.4em;
@@ -1716,222 +1451,182 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     line-height: 1.3em;
     margin: -9px 0 22px; }
     @media (max-width: 485px) {
-      /* line 147, ../scss/components/_soe_news.scss */
       #block-ds-extras-banner-overlay .field-name-title h1 {
         font-size: 1.2em; } }
     @media (max-width: 380px) {
-      /* line 147, ../scss/components/_soe_news.scss */
       #block-ds-extras-banner-overlay .field-name-title h1 {
         font-size: 1em; } }
-  /* line 164, ../scss/components/_soe_news.scss */
   .logged-in #block-ds-extras-banner-overlay {
     top: 285px; }
     @media (max-width: 1200px) {
-      /* line 164, ../scss/components/_soe_news.scss */
       .logged-in #block-ds-extras-banner-overlay {
         top: 325px; } }
     @media (max-width: 767px) {
-      /* line 164, ../scss/components/_soe_news.scss */
       .logged-in #block-ds-extras-banner-overlay {
         top: -305px; } }
     @media (max-width: 380px) {
-      /* line 164, ../scss/components/_soe_news.scss */
       .logged-in #block-ds-extras-banner-overlay {
         top: -325px; } }
     @media (max-width: 485px) {
-      /* line 176, ../scss/components/_soe_news.scss */
       .logged-in #block-ds-extras-banner-overlay .field-name-title h1 {
         font-size: 1.2em; } }
     @media (max-width: 485px) {
-      /* line 182, ../scss/components/_soe_news.scss */
       .logged-in #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
         font-size: 0.75em; } }
 
-/* line 194, ../scss/components/_soe_news.scss */
 .view-stanford-news-featured .feat-news-container .feat-news-img {
   overflow: hidden; }
-  /* line 197, ../scss/components/_soe_news.scss */
   .view-stanford-news-featured .feat-news-container .feat-news-img:hover img {
     -webkit-transform: scale(1.03);
     -moz-transform: scale(1.03);
     -o-transform: scale(1.03);
     transform: scale(1.03); }
-  /* line 201, ../scss/components/_soe_news.scss */
   .view-stanford-news-featured .feat-news-container .feat-news-img img {
     -webkit-transition: all 1s ease;
     -moz-transition: all 1s ease;
     -o-transition: all 1s ease;
     transition: all 1s ease;
     width: 100%; }
-/* line 207, ../scss/components/_soe_news.scss */
+
 .view-stanford-news-featured .feat-news-container .feat-news-content-container {
   background: #FFFFFF;
   padding: 15px 30px 30px;
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 212, ../scss/components/_soe_news.scss */
   .view-stanford-news-featured .feat-news-container .feat-news-content-container .feat-news-date {
     color: #606060;
     font-size: 1em;
     font-weight: 100;
     margin-bottom: 10px; }
-  /* line 220, ../scss/components/_soe_news.scss */
   .view-stanford-news-featured .feat-news-container .feat-news-content-container .feat-news-title h2 {
     font-size: 1.4em; }
-    /* line 223, ../scss/components/_soe_news.scss */
     .view-stanford-news-featured .feat-news-container .feat-news-content-container .feat-news-title h2 a {
       -webkit-text-decoration-color: #FF525C;
       text-decoration-color: #FF525C; }
-      /* line 226, ../scss/components/_soe_news.scss */
       .view-stanford-news-featured .feat-news-container .feat-news-content-container .feat-news-title h2 a:focus, .view-stanford-news-featured .feat-news-container .feat-news-content-container .feat-news-title h2 a:hover {
         -webkit-text-decoration-color: #333333;
         text-decoration-color: #333333; }
-  /* line 234, ../scss/components/_soe_news.scss */
   .view-stanford-news-featured .feat-news-container .feat-news-content-container .feat-news-teaser {
     font-size: 0.9em;
     line-height: 1.3em; }
 
-/* line 246, ../scss/components/_soe_news.scss */
 .view-stanford-news-with-title h3,
 .view-stanford-news-image-title h3 {
   font-size: 1.1em;
   line-height: 1.1em;
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   text-decoration: none; }
-  /* line 251, ../scss/components/_soe_news.scss */
   .view-stanford-news-with-title h3 a,
   .view-stanford-news-image-title h3 a {
     text-decoration: none; }
-/* line 255, ../scss/components/_soe_news.scss */
+
 .view-stanford-news-with-title .views-row,
 .view-stanford-news-image-title .views-row {
   margin-bottom: 1.5em; }
-/* line 260, ../scss/components/_soe_news.scss */
+
 .view-stanford-news-with-title img,
 .view-stanford-news-image-title img {
   margin-bottom: 10px; }
 
-/* line 269, ../scss/components/_soe_news.scss */
 .view-stanford-news-with-title h3 a {
   text-decoration: none; }
-  /* line 271, ../scss/components/_soe_news.scss */
   .view-stanford-news-with-title h3 a:hover {
     text-decoration: underline; }
-/* line 278, ../scss/components/_soe_news.scss */
+
 .view-stanford-news-with-title .more-link a:hover {
   text-decoration: underline; }
 
-/* line 287, ../scss/components/_soe_news.scss */
 .page-news .date-display-single {
   font-weight: 600; }
 
-/* line 291, ../scss/components/_soe_news.scss */
 .view-soe-school-news-with-teaser {
   margin-top: 12px; }
 
-/* line 10, ../scss/components/_soe_events.scss */
 .node-type-stanford-event .date-display-single {
   font-weight: 600; }
-/* line 13, ../scss/components/_soe_events.scss */
+
 .node-type-stanford-event h1 {
   font-size: 2.4em; }
   @media (min-width: 580px) {
-    /* line 13, ../scss/components/_soe_events.scss */
     .node-type-stanford-event h1 {
       width: 70%; } }
+
 @media (min-width: 580px) {
-  /* line 20, ../scss/components/_soe_events.scss */
   .node-type-stanford-event .main #block-system-main {
     margin: 0 auto 1em;
     width: 70%; } }
-/* line 26, ../scss/components/_soe_events.scss */
+
 .node-type-stanford-event .main #block-system-main.block {
   margin-bottom: 0; }
-/* line 29, ../scss/components/_soe_events.scss */
+
 .node-type-stanford-event .descriptor {
   font-size: 1.1em; }
 
-/* line 36, ../scss/components/_soe_events.scss */
 .page-events .date-display-single {
   font-weight: 600; }
 
-/* line 40, ../scss/components/_soe_events.scss */
 .view-stanford-events-views {
   margin-top: 12px; }
 
 @media (max-width: 767px) {
-  /* line 48, ../scss/components/_soe_events.scss */
   .front .view-stanford-event-featured.vertical-event {
     margin: 0 auto; } }
-/* line 54, ../scss/components/_soe_events.scss */
+
 .view-stanford-event-featured.vertical-event .feat-events-container {
   overflow: hidden;
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 58, ../scss/components/_soe_events.scss */
   .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-date-time-container {
     position: relative;
     background: #FFFFFF;
     height: 93px; }
     @media (min-width: 768px) and (max-width: 979px) {
-      /* line 58, ../scss/components/_soe_events.scss */
       .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-date-time-container {
         height: auto; } }
-    /* line 66, ../scss/components/_soe_events.scss */
     .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-date-time-container .date-stacked {
       float: left;
       height: 93px;
       width: 93px;
       margin: 0;
       padding: 0; }
-      /* line 73, ../scss/components/_soe_events.scss */
       .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-date-time-container .date-stacked .date-month {
         font-size: 1em;
         line-height: 38px;
         margin-top: 11px; }
-      /* line 79, ../scss/components/_soe_events.scss */
       .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-date-time-container .date-stacked .date-day {
         font-size: 1.9em; }
-    /* line 84, ../scss/components/_soe_events.scss */
     .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-date-time-container .feat-events-label-time-container {
       position: absolute;
       bottom: -7px;
       left: 108px; }
       @media (min-width: 768px) and (max-width: 979px) {
-        /* line 84, ../scss/components/_soe_events.scss */
         .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-date-time-container .feat-events-label-time-container {
           position: static;
           clear: both;
           padding: 10px 30px 0; } }
-      /* line 94, ../scss/components/_soe_events.scss */
       .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-date-time-container .feat-events-label-time-container .feat-events-label p {
         color: #606060;
         font-weight: 100;
         margin-bottom: 0; }
-  /* line 102, ../scss/components/_soe_events.scss */
   .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-content-container {
     background: #FFFFFF;
     padding: 30px; }
-    /* line 107, ../scss/components/_soe_events.scss */
     .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-content-container .feat-events-title h2 {
       font-size: 1.4em;
       margin-top: 0; }
-      /* line 111, ../scss/components/_soe_events.scss */
       .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-content-container .feat-events-title h2 a {
         -webkit-text-decoration-color: #FFBD54;
         text-decoration-color: #FFBD54; }
-        /* line 114, ../scss/components/_soe_events.scss */
         .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-content-container .feat-events-title h2 a:focus, .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-content-container .feat-events-title h2 a:hover {
           -webkit-text-decoration-color: #333333;
           text-decoration-color: #333333; }
-    /* line 122, ../scss/components/_soe_events.scss */
     .view-stanford-event-featured.vertical-event .feat-events-container .feat-events-content-container .feat-events-teaser {
       font-size: 0.9em;
       line-height: 1.3em; }
+
 @media (min-width: 979px) {
-  /* line 131, ../scss/components/_soe_events.scss */
   .view-stanford-event-featured.horizontal-event .feat-events-container {
     background: #FFFFFF;
     display: flex;
@@ -1939,37 +1634,31 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); } }
-/* line 139, ../scss/components/_soe_events.scss */
+
 .view-stanford-event-featured.horizontal-event .feat-events-container .feat-events-img-container {
   flex-shrink: 0; }
   @media (max-width: 979px) {
-    /* line 142, ../scss/components/_soe_events.scss */
     .view-stanford-event-featured.horizontal-event .feat-events-container .feat-events-img-container img {
       width: 100%; } }
-/* line 149, ../scss/components/_soe_events.scss */
+
 .view-stanford-event-featured.horizontal-event .feat-events-container .feat-events-content-container {
   padding-left: 30px; }
   @media (max-width: 979px) {
-    /* line 149, ../scss/components/_soe_events.scss */
     .view-stanford-event-featured.horizontal-event .feat-events-container .feat-events-content-container {
       background: #FFFFFF;
       padding: 30px;
       -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
       -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
       box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); } }
-  /* line 158, ../scss/components/_soe_events.scss */
   .view-stanford-event-featured.horizontal-event .feat-events-container .feat-events-content-container .feat-events-title h2 {
     font-size: 1.4em;
     margin-top: 0; }
-  /* line 163, ../scss/components/_soe_events.scss */
   .view-stanford-event-featured.horizontal-event .feat-events-container .feat-events-content-container .feat-events-title a {
     -webkit-text-decoration-color: #FFBD54;
     text-decoration-color: #FFBD54; }
-    /* line 166, ../scss/components/_soe_events.scss */
     .view-stanford-event-featured.horizontal-event .feat-events-container .feat-events-content-container .feat-events-title a:focus, .view-stanford-event-featured.horizontal-event .feat-events-container .feat-events-content-container .feat-events-title a:hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
-  /* line 173, ../scss/components/_soe_events.scss */
   .view-stanford-event-featured.horizontal-event .feat-events-container .feat-events-content-container .date-stacked {
     margin: 0 0 20px;
     height: 45px;
@@ -1977,51 +1666,42 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-    /* line 179, ../scss/components/_soe_events.scss */
     .view-stanford-event-featured.horizontal-event .feat-events-container .feat-events-content-container .date-stacked .date-month {
       font-size: 0.9em;
       line-height: 25px; }
 
-/* line 191, ../scss/components/_soe_events.scss */
 #content-body .content .field-name-field-s-event-map-link a.btn {
   margin: 0; }
 
 @media (min-width: 767px) {
-  /* line 10, ../scss/components/_soe_beans.scss */
   #content-body-bottom .bean-stanford-call-to-action {
     margin-bottom: 100px; } }
-/* line 16, ../scss/components/_soe_beans.scss */
+
 .bean-stanford-call-to-action a.group-s-cta-link:hover img {
   -webkit-transform: scale(1.03);
   -moz-transform: scale(1.03);
   -o-transform: scale(1.03);
   transform: scale(1.03); }
-/* line 20, ../scss/components/_soe_beans.scss */
+
 .bean-stanford-call-to-action .field-name-field-s-cta-image {
   overflow: hidden; }
-  /* line 23, ../scss/components/_soe_beans.scss */
   .bean-stanford-call-to-action .field-name-field-s-cta-image img {
     -webkit-transition: all 1s ease;
     -moz-transition: all 1s ease;
     -o-transition: all 1s ease;
     transition: all 1s ease; }
-/* line 28, ../scss/components/_soe_beans.scss */
+
 .bean-stanford-call-to-action .group-s-cta-title-style {
   padding: 18px 0 22px; }
   @media (max-width: 480px) {
-    /* line 28, ../scss/components/_soe_beans.scss */
     .bean-stanford-call-to-action .group-s-cta-title-style {
       padding: 12px 0 14px; } }
-  /* line 34, ../scss/components/_soe_beans.scss */
   .turquoise .bean-stanford-call-to-action .group-s-cta-title-style {
     background: #00ECE9; }
-  /* line 38, ../scss/components/_soe_beans.scss */
   .orange .bean-stanford-call-to-action .group-s-cta-title-style {
     background: #FFBD54; }
-  /* line 42, ../scss/components/_soe_beans.scss */
   .pink .bean-stanford-call-to-action .group-s-cta-title-style {
     background: #FF525C; }
-  /* line 46, ../scss/components/_soe_beans.scss */
   .bean-stanford-call-to-action .group-s-cta-title-style h2 {
     color: #000000;
     font-size: 1.1em;
@@ -2029,35 +1709,31 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     font-weight: 400; }
 
 @media (min-width: 1200px) {
-  /* line 55, ../scss/components/_soe_beans.scss */
   .content-body [id*="block-bean-sitewide-facebook-cta-block"].block[class*="span"],
   .content-body [id*="block-bean-sitewide-instagram-cta-block"].block[class*="span"],
   .content-body [id*="block-bean-sitewide-twitter-cta-block"].block[class*="span"] {
     width: 20%; } }
+
 @media (max-width: 767px) {
-  /* line 55, ../scss/components/_soe_beans.scss */
   .content-body [id*="block-bean-sitewide-facebook-cta-block"].block[class*="span"],
   .content-body [id*="block-bean-sitewide-instagram-cta-block"].block[class*="span"],
   .content-body [id*="block-bean-sitewide-twitter-cta-block"].block[class*="span"] {
     width: 50%;
     margin: 0 25% 20px; } }
-/* line 66, ../scss/components/_soe_beans.scss */
+
 .content-body [id*="block-bean-sitewide-facebook-cta-block"].block[class*="span"] .field-name-field-s-cta-icon,
 .content-body [id*="block-bean-sitewide-instagram-cta-block"].block[class*="span"] .field-name-field-s-cta-icon,
 .content-body [id*="block-bean-sitewide-twitter-cta-block"].block[class*="span"] .field-name-field-s-cta-icon {
   font-size: 2.5em; }
 
 @media (min-width: 1200px) {
-  /* line 71, ../scss/components/_soe_beans.scss */
   [id*="block-bean-sitewide-instagram-cta-block"].block[class*="span"] {
     margin-left: 17.25%; } }
 
 @media (min-width: 1200px) {
-  /* line 77, ../scss/components/_soe_beans.scss */
   [id*="block-bean-sitewide-twitter-cta-block"].block[class*="span"] {
     margin-right: 17.25%; } }
 
-/* line 87, ../scss/components/_soe_beans.scss */
 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container,
 .bean-stanford-postcard-linked .postcard,
@@ -2069,14 +1745,12 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
   @media (max-width: 767px) {
-    /* line 87, ../scss/components/_soe_beans.scss */
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container,
     .bean-stanford-postcard-linked .postcard,
     .bean-stanford-postcard-linked .postcard-linked-container {
       display: block;
       padding: 0; } }
-  /* line 98, ../scss/components/_soe_beans.scss */
   .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container,
   .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container,
   .bean-stanford-postcard-linked .postcard a.postcard-linked-img-container,
@@ -2085,20 +1759,17 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     /*** SPAN 12 BEAN RESPONSIVE ***/
     margin-right: 30px; }
     @media (max-width: 979px) {
-      /* line 98, ../scss/components/_soe_beans.scss */
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container,
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container,
       .bean-stanford-postcard-linked .postcard a.postcard-linked-img-container,
       .bean-stanford-postcard-linked .postcard-linked-container a.postcard-linked-img-container {
         flex-shrink: .9; } }
     @media (max-width: 767px) {
-      /* line 98, ../scss/components/_soe_beans.scss */
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container,
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container,
       .bean-stanford-postcard-linked .postcard a.postcard-linked-img-container,
       .bean-stanford-postcard-linked .postcard-linked-container a.postcard-linked-img-container {
         margin-right: 0; } }
-    /* line 111, ../scss/components/_soe_beans.scss */
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container:hover img,
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container:hover img,
     .bean-stanford-postcard-linked .postcard a.postcard-linked-img-container:hover img,
@@ -2107,13 +1778,11 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
       -moz-transform: scale(1.03);
       -o-transform: scale(1.03);
       transform: scale(1.03); }
-    /* line 115, ../scss/components/_soe_beans.scss */
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container .postcard-linked-img,
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img,
     .bean-stanford-postcard-linked .postcard a.postcard-linked-img-container .postcard-linked-img,
     .bean-stanford-postcard-linked .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img {
       position: relative; }
-      /* line 118, ../scss/components/_soe_beans.scss */
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-image-image,
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-post-link-image,
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-image-image,
@@ -2123,7 +1792,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
       .bean-stanford-postcard-linked .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-image-image,
       .bean-stanford-postcard-linked .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-post-link-image {
         overflow: hidden; }
-        /* line 122, ../scss/components/_soe_beans.scss */
         .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-image-image img,
         .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-post-link-image img,
         .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-image-image img,
@@ -2137,7 +1805,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
           -o-transition: all 1s ease;
           transition: all 1s ease; }
           @media (max-width: 767px) {
-            /* line 122, ../scss/components/_soe_beans.scss */
             .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-image-image img,
             .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-post-link-image img,
             .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-image-image img,
@@ -2147,7 +1814,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
             .bean-stanford-postcard-linked .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-image-image img,
             .bean-stanford-postcard-linked .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .field-name-field-s-post-link-image img {
               width: 100%; } }
-      /* line 130, ../scss/components/_soe_beans.scss */
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow,
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow,
       .bean-stanford-postcard-linked .postcard a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow,
@@ -2157,7 +1823,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
         right: 20px;
         width: 40px;
         height: 40px; }
-        /* line 137, ../scss/components/_soe_beans.scss */
         .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img,
         .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img,
         .bean-stanford-postcard-linked .postcard a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img,
@@ -2167,20 +1832,17 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
           vertical-align: -9px;
           padding: 3px 8px; }
           @media (max-width: 767px) {
-            /* line 137, ../scss/components/_soe_beans.scss */
             .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img,
             .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img,
             .bean-stanford-postcard-linked .postcard a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img,
             .bean-stanford-postcard-linked .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img {
               vertical-align: -12px; } }
           @media (max-width: 480px) {
-            /* line 137, ../scss/components/_soe_beans.scss */
             .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img,
             .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img,
             .bean-stanford-postcard-linked .postcard a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img,
             .bean-stanford-postcard-linked .postcard-linked-container a.postcard-linked-img-container .postcard-linked-img .postcard-linked-arrow img {
               vertical-align: -14px; } }
-  /* line 153, ../scss/components/_soe_beans.scss */
   .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
   .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container,
   .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-content,
@@ -2192,7 +1854,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     width: 100%;
     /*** STANDARDIZE PADDING INSIDE POSTCARD LINKED BLOCK ***/ }
     @media (max-width: 767px) {
-      /* line 153, ../scss/components/_soe_beans.scss */
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container,
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-content,
@@ -2203,7 +1864,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
       .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container {
         width: auto;
         padding: 30px; } }
-    /* line 161, ../scss/components/_soe_beans.scss */
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .field-name-field-s-postcard-body,
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .field-name-field-s-post-link-body,
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container .field-name-field-s-postcard-body,
@@ -2222,7 +1882,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .field-name-field-s-post-link-body {
       font-size: 0.9em;
       line-height: 1.3em; }
-      /* line 166, ../scss/components/_soe_beans.scss */
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .field-name-field-s-postcard-body:last-child,
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .field-name-field-s-post-link-body:last-child,
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container .field-name-field-s-postcard-body:last-child,
@@ -2240,7 +1899,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
       .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .field-name-field-s-postcard-body:last-child,
       .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .field-name-field-s-post-link-body:last-child {
         margin-bottom: 0; }
-    /* line 171, ../scss/components/_soe_beans.scss */
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .field-name-title,
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .postcard-linked-title,
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container .field-name-title,
@@ -2258,7 +1916,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .field-name-title,
     .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .postcard-linked-title {
       margin-bottom: 1em; }
-      /* line 175, ../scss/components/_soe_beans.scss */
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .field-name-title a,
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .postcard-linked-title a,
       .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container .field-name-title a,
@@ -2286,7 +1943,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
         -webkit-text-decoration-color: #00ECE9;
         text-decoration-color: #00ECE9; }
         @media (max-width: 767px) {
-          /* line 175, ../scss/components/_soe_beans.scss */
           .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .field-name-title a,
           .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .postcard-linked-title a,
           .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container .field-name-title a,
@@ -2304,7 +1960,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
           .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .field-name-title a,
           .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .postcard-linked-title a {
             margin-top: 20px; } }
-        /* line 188, ../scss/components/_soe_beans.scss */
         .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .field-name-title a:focus, .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .field-name-title a:hover,
         .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .postcard-linked-title a:focus,
         .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .postcard-linked-title a:hover,
@@ -2338,7 +1993,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
         .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .postcard-linked-title a:hover {
           -webkit-text-decoration-color: #333333;
           text-decoration-color: #333333; }
-    /* line 196, ../scss/components/_soe_beans.scss */
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .postcard-body p:last-child,
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .postcard-linked-body p:last-child,
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container .postcard-body p:last-child,
@@ -2356,7 +2010,6 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .postcard-body p:last-child,
     .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .postcard-linked-body p:last-child {
       margin-bottom: .8em; }
-    /* line 201, ../scss/components/_soe_beans.scss */
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .postcard-body,
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content .postcard-linked-body p,
     .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container .postcard-body,
@@ -2374,77 +2027,93 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .postcard-body,
     .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container .postcard-linked-body p {
       margin-bottom: 1em; }
-  /* line 207, ../scss/components/_soe_beans.scss */
   .bean-stanford-postcard.view-mode-stanford_soe_default .postcard a.btn,
   .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container a.btn,
   .bean-stanford-postcard-linked .postcard a.btn,
   .bean-stanford-postcard-linked .postcard-linked-container a.btn {
     text-decoration: none;
     margin-bottom: 0; }
-/* line 213, ../scss/components/_soe_beans.scss */
+
 .bean-stanford-postcard.view-mode-stanford_soe_default.postcard-linked-arrow-color-orange .postcard-linked-arrow,
 .bean-stanford-postcard-linked.postcard-linked-arrow-color-orange .postcard-linked-arrow {
   background: #FFBD54; }
-/* line 217, ../scss/components/_soe_beans.scss */
+
 .bean-stanford-postcard.view-mode-stanford_soe_default.postcard-linked-arrow-color-turquoise .postcard-linked-arrow,
 .bean-stanford-postcard-linked.postcard-linked-arrow-color-turquoise .postcard-linked-arrow {
   background: #00ECE9; }
-/* line 221, ../scss/components/_soe_beans.scss */
+
 .bean-stanford-postcard.view-mode-stanford_soe_default.postcard-linked-arrow-color-pink .postcard-linked-arrow,
 .bean-stanford-postcard-linked.postcard-linked-arrow-color-pink .postcard-linked-arrow {
   background: #FF525C; }
-/* line 232, ../scss/components/_soe_beans.scss */
+
 .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
-.span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container, .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
-.span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container, .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
-.span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container, .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
-.span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container, .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
-.span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container, .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
-.span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container, .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
+.span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container,
+.span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
+.span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container,
+.span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
+.span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container,
+.span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
+.span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container,
+.span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
+.span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container,
+.span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
+.span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container,
+.span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard,
 .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container, .span1
 .bean-stanford-postcard-linked .postcard,
 .span1
-.bean-stanford-postcard-linked .postcard-linked-container, .span2
+.bean-stanford-postcard-linked .postcard-linked-container,
+.span2
 .bean-stanford-postcard-linked .postcard,
 .span2
-.bean-stanford-postcard-linked .postcard-linked-container, .span3
+.bean-stanford-postcard-linked .postcard-linked-container,
+.span3
 .bean-stanford-postcard-linked .postcard,
 .span3
-.bean-stanford-postcard-linked .postcard-linked-container, .span4
+.bean-stanford-postcard-linked .postcard-linked-container,
+.span4
 .bean-stanford-postcard-linked .postcard,
 .span4
-.bean-stanford-postcard-linked .postcard-linked-container, .span5
+.bean-stanford-postcard-linked .postcard-linked-container,
+.span5
 .bean-stanford-postcard-linked .postcard,
 .span5
-.bean-stanford-postcard-linked .postcard-linked-container, .span6
+.bean-stanford-postcard-linked .postcard-linked-container,
+.span6
 .bean-stanford-postcard-linked .postcard,
 .span6
-.bean-stanford-postcard-linked .postcard-linked-container, .span7
+.bean-stanford-postcard-linked .postcard-linked-container,
+.span7
 .bean-stanford-postcard-linked .postcard,
 .span7
 .bean-stanford-postcard-linked .postcard-linked-container {
   display: block;
   padding: 0; }
-  /* line 237, ../scss/components/_soe_beans.scss */
   .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
   .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img-container,
   .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-image,
-  .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container, .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
+  .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container,
+  .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
   .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img-container,
   .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-image,
-  .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container, .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
+  .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container,
+  .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
   .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img-container,
   .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-image,
-  .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container, .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
+  .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container,
+  .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
   .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img-container,
   .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-image,
-  .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container, .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
+  .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container,
+  .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
   .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img-container,
   .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-image,
-  .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container, .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
+  .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container,
+  .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
   .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img-container,
   .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-image,
-  .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container, .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
+  .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container,
+  .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-image,
   .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img-container,
   .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-image,
   .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img-container, .span1
@@ -2454,42 +2123,48 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   .span1
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-image,
   .span1
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container, .span2
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container,
+  .span2
   .bean-stanford-postcard-linked .postcard .postcard-image,
   .span2
   .bean-stanford-postcard-linked .postcard .postcard-linked-img-container,
   .span2
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-image,
   .span2
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container, .span3
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container,
+  .span3
   .bean-stanford-postcard-linked .postcard .postcard-image,
   .span3
   .bean-stanford-postcard-linked .postcard .postcard-linked-img-container,
   .span3
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-image,
   .span3
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container, .span4
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container,
+  .span4
   .bean-stanford-postcard-linked .postcard .postcard-image,
   .span4
   .bean-stanford-postcard-linked .postcard .postcard-linked-img-container,
   .span4
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-image,
   .span4
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container, .span5
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container,
+  .span5
   .bean-stanford-postcard-linked .postcard .postcard-image,
   .span5
   .bean-stanford-postcard-linked .postcard .postcard-linked-img-container,
   .span5
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-image,
   .span5
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container, .span6
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container,
+  .span6
   .bean-stanford-postcard-linked .postcard .postcard-image,
   .span6
   .bean-stanford-postcard-linked .postcard .postcard-linked-img-container,
   .span6
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-image,
   .span6
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container, .span7
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container,
+  .span7
   .bean-stanford-postcard-linked .postcard .postcard-image,
   .span7
   .bean-stanford-postcard-linked .postcard .postcard-linked-img-container,
@@ -2498,26 +2173,31 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   .span7
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container {
     margin-right: 0; }
-  /* line 244, ../scss/components/_soe_beans.scss */
   .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
   .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
+  .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
   .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
+  .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
   .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
+  .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
   .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
+  .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
   .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
+  .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
   .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
+  .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .image-container .field-name-field-s-post-link-image img,
   .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
   .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span1
@@ -2527,42 +2207,48 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   .span1
   .bean-stanford-postcard-linked .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
   .span1
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span2
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span2
   .bean-stanford-postcard-linked .postcard .image-container .field-name-field-s-post-link-image img,
   .span2
   .bean-stanford-postcard-linked .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span2
   .bean-stanford-postcard-linked .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
   .span2
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span3
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span3
   .bean-stanford-postcard-linked .postcard .image-container .field-name-field-s-post-link-image img,
   .span3
   .bean-stanford-postcard-linked .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span3
   .bean-stanford-postcard-linked .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
   .span3
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span4
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span4
   .bean-stanford-postcard-linked .postcard .image-container .field-name-field-s-post-link-image img,
   .span4
   .bean-stanford-postcard-linked .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span4
   .bean-stanford-postcard-linked .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
   .span4
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span5
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span5
   .bean-stanford-postcard-linked .postcard .image-container .field-name-field-s-post-link-image img,
   .span5
   .bean-stanford-postcard-linked .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span5
   .bean-stanford-postcard-linked .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
   .span5
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span6
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span6
   .bean-stanford-postcard-linked .postcard .image-container .field-name-field-s-post-link-image img,
   .span6
   .bean-stanford-postcard-linked .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span6
   .bean-stanford-postcard-linked .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
   .span6
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span7
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span7
   .bean-stanford-postcard-linked .postcard .image-container .field-name-field-s-post-link-image img,
   .span7
   .bean-stanford-postcard-linked .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
@@ -2571,26 +2257,31 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   .span7
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img {
     width: 100%; }
-  /* line 249, ../scss/components/_soe_beans.scss */
   .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
   .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container,
   .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-content,
-  .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container, .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
+  .span1 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container,
+  .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
   .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container,
   .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-content,
-  .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container, .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
+  .span2 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container,
+  .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
   .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container,
   .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-content,
-  .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container, .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
+  .span3 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container,
+  .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
   .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container,
   .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-content,
-  .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container, .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
+  .span4 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container,
+  .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
   .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container,
   .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-content,
-  .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container, .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
+  .span5 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container,
+  .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
   .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container,
   .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-content,
-  .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container, .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
+  .span6 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container,
+  .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-content,
   .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard .postcard-linked-content-container,
   .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-content,
   .span7 .bean-stanford-postcard.view-mode-stanford_soe_default .postcard-linked-container .postcard-linked-content-container, .span1
@@ -2600,42 +2291,48 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   .span1
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-content,
   .span1
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container, .span2
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container,
+  .span2
   .bean-stanford-postcard-linked .postcard .postcard-content,
   .span2
   .bean-stanford-postcard-linked .postcard .postcard-linked-content-container,
   .span2
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-content,
   .span2
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container, .span3
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container,
+  .span3
   .bean-stanford-postcard-linked .postcard .postcard-content,
   .span3
   .bean-stanford-postcard-linked .postcard .postcard-linked-content-container,
   .span3
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-content,
   .span3
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container, .span4
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container,
+  .span4
   .bean-stanford-postcard-linked .postcard .postcard-content,
   .span4
   .bean-stanford-postcard-linked .postcard .postcard-linked-content-container,
   .span4
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-content,
   .span4
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container, .span5
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container,
+  .span5
   .bean-stanford-postcard-linked .postcard .postcard-content,
   .span5
   .bean-stanford-postcard-linked .postcard .postcard-linked-content-container,
   .span5
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-content,
   .span5
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container, .span6
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container,
+  .span6
   .bean-stanford-postcard-linked .postcard .postcard-content,
   .span6
   .bean-stanford-postcard-linked .postcard .postcard-linked-content-container,
   .span6
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-content,
   .span6
-  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container, .span7
+  .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container,
+  .span7
   .bean-stanford-postcard-linked .postcard .postcard-content,
   .span7
   .bean-stanford-postcard-linked .postcard .postcard-linked-content-container,
@@ -2645,27 +2342,23 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container {
     width: auto;
     padding: 30px; }
-/* line 256, ../scss/components/_soe_beans.scss */
+
 .span12 .bean-stanford-postcard.view-mode-stanford_soe_default, .span12
 .bean-stanford-postcard-linked {
   margin: 0 10%; }
   @media (max-width: 979px) {
-    /* line 256, ../scss/components/_soe_beans.scss */
     .span12 .bean-stanford-postcard.view-mode-stanford_soe_default, .span12
     .bean-stanford-postcard-linked {
       margin: 0; } }
   @media (max-width: 767px) {
-    /* line 256, ../scss/components/_soe_beans.scss */
     .span12 .bean-stanford-postcard.view-mode-stanford_soe_default, .span12
     .bean-stanford-postcard-linked {
       margin: 0 10%; } }
   @media (max-width: 580px) {
-    /* line 256, ../scss/components/_soe_beans.scss */
     .span12 .bean-stanford-postcard.view-mode-stanford_soe_default, .span12
     .bean-stanford-postcard-linked {
       margin: 0; } }
 
-/* line 273, ../scss/components/_soe_beans.scss */
 .bean-stanford-testimonial-block .postcard {
   background: #FFFFFF;
   padding: 0 56px 40px;
@@ -2673,11 +2366,10 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
   @media (max-width: 767px) {
-    /* line 273, ../scss/components/_soe_beans.scss */
     .bean-stanford-testimonial-block .postcard {
       display: block;
       padding: 0 44px 40px; } }
-/* line 286, ../scss/components/_soe_beans.scss */
+
 .bean-stanford-testimonial-block .field-name-field-s-testimonial-superhead {
   border-top: #00ECE9 6px solid;
   display: inline-block;
@@ -2685,41 +2377,35 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   font-family: "Roboto Slab", serif;
   margin-bottom: 20px;
   padding-top: 12px; }
-  /* line 294, ../scss/components/_soe_beans.scss */
   .bean-stanford-testimonial-block .field-name-field-s-testimonial-superhead.field {
     margin-bottom: 2em; }
     @media (max-width: 580px) {
-      /* line 294, ../scss/components/_soe_beans.scss */
       .bean-stanford-testimonial-block .field-name-field-s-testimonial-superhead.field {
         margin-bottom: 1em; } }
-/* line 303, ../scss/components/_soe_beans.scss */
+
 .bean-stanford-testimonial-block .field-name-field-s-testimonial-quote {
   font-family: "Roboto Slab", serif; }
   @media (max-width: 979px) {
-    /* line 303, ../scss/components/_soe_beans.scss */
     .bean-stanford-testimonial-block .field-name-field-s-testimonial-quote {
       font-size: 22px;
       line-height: 1.5em; } }
   @media (max-width: 580px) {
-    /* line 303, ../scss/components/_soe_beans.scss */
     .bean-stanford-testimonial-block .field-name-field-s-testimonial-quote {
       font-size: 18px; } }
-/* line 316, ../scss/components/_soe_beans.scss */
+
 .bean-stanford-testimonial-block .field-name-field-s-testimonial-credits {
   font-size: 18px;
   letter-spacing: 0;
   margin-top: 15px; }
   @media (max-width: 580px) {
-    /* line 316, ../scss/components/_soe_beans.scss */
     .bean-stanford-testimonial-block .field-name-field-s-testimonial-credits {
       font-size: 16px; } }
-  /* line 325, ../scss/components/_soe_beans.scss */
   .bean-stanford-testimonial-block .field-name-field-s-testimonial-credits.field {
     margin-bottom: 0; }
-/* line 330, ../scss/components/_soe_beans.scss */
+
 .bean-stanford-testimonial-block .group-s-credits-style {
   margin-bottom: 0; }
-/* line 335, ../scss/components/_soe_beans.scss */
+
 .bean-stanford-testimonial-block .quote .field-item::after {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 56px;
@@ -2727,67 +2413,56 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   opacity: 1;
   top: 30; }
   @media (max-width: 580px) {
-    /* line 335, ../scss/components/_soe_beans.scss */
     .bean-stanford-testimonial-block .quote .field-item::after {
       font-size: 40px; } }
 
-/* line 350, ../scss/components/_soe_beans.scss */
 .span12 .bean-stanford-testimonial-block {
   margin: 0 10%; }
   @media (max-width: 979px) {
-    /* line 350, ../scss/components/_soe_beans.scss */
     .span12 .bean-stanford-testimonial-block {
       margin: 0; } }
   @media (max-width: 767px) {
-    /* line 350, ../scss/components/_soe_beans.scss */
     .span12 .bean-stanford-testimonial-block {
       margin: 0 10%; } }
   @media (max-width: 580px) {
-    /* line 350, ../scss/components/_soe_beans.scss */
     .span12 .bean-stanford-testimonial-block {
       margin: 0; } }
-/* line 366, ../scss/components/_soe_beans.scss */
+
 .span12 .bean-stanford-postcard-linked {
   margin: 0; }
 
-/* line 372, ../scss/components/_soe_beans.scss */
 .quote::before {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 400;
   opacity: 1; }
-/* line 378, ../scss/components/_soe_beans.scss */
+
 .quote::after {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 400;
   opacity: 1; }
 
-/* line 386, ../scss/components/_soe_beans.scss */
 div.quote p:last-child::after {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 400;
   opacity: 1; }
-/* line 392, ../scss/components/_soe_beans.scss */
+
 div.quote::before {
   font-size: 56px; }
   @media (max-width: 580px) {
-    /* line 392, ../scss/components/_soe_beans.scss */
     div.quote::before {
       font-size: 40px; } }
 
-/* line 402, ../scss/components/_soe_beans.scss */
 blockquote.quote p:last-child::after {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 400;
   opacity: 1; }
-/* line 408, ../scss/components/_soe_beans.scss */
+
 blockquote.quote::before {
   font-size: 56px; }
   @media (max-width: 580px) {
-    /* line 408, ../scss/components/_soe_beans.scss */
     blockquote.quote::before {
       font-size: 40px; } }
 
-/* line 417, ../scss/components/_soe_beans.scss */
 p.superhead {
   color: #333333;
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -2796,7 +2471,6 @@ p.superhead {
   line-height: 1.2em;
   margin-bottom: .6em; }
 
-/* line 426, ../scss/components/_soe_beans.scss */
 .infotext {
   font-size: 56px;
   font-family: "Roboto Slab", serif;
@@ -2806,11 +2480,9 @@ p.superhead {
   letter-spacing: 0;
   margin: 0; }
 
-/* line 436, ../scss/components/_soe_beans.scss */
 p.infotext {
   margin: 0; }
 
-/* line 13, ../scss/components/_soe_dm_brand_bar.scss */
 .node-type-stanford-collection a,
 .node-type-stanford-magazine-issue a,
 .page-taxonomy-term a,
@@ -2818,7 +2490,7 @@ p.infotext {
 .page-magazine-all a,
 .node-type-stanford-magazine-article a {
   font-weight: 400; }
-/* line 19, ../scss/components/_soe_dm_brand_bar.scss */
+
 .node-type-stanford-collection #header #logo img,
 .node-type-stanford-magazine-issue #header #logo img,
 .page-taxonomy-term #header #logo img,
@@ -2826,8 +2498,8 @@ p.infotext {
 .page-magazine-all #header #logo img,
 .node-type-stanford-magazine-article #header #logo img {
   max-width: 90px; }
+
 @media (max-width: 480px) {
-  /* line 23, ../scss/components/_soe_dm_brand_bar.scss */
   .node-type-stanford-collection #header #logo.logo-mobile,
   .node-type-stanford-magazine-issue #header #logo.logo-mobile,
   .page-taxonomy-term #header #logo.logo-mobile,
@@ -2835,7 +2507,7 @@ p.infotext {
   .page-magazine-all #header #logo.logo-mobile,
   .node-type-stanford-magazine-article #header #logo.logo-mobile {
     padding: 0 5px 0 0; } }
-/* line 30, ../scss/components/_soe_dm_brand_bar.scss */
+
 .node-type-stanford-collection #header.header,
 .node-type-stanford-magazine-issue #header.header,
 .page-taxonomy-term #header.header,
@@ -2846,7 +2518,6 @@ p.infotext {
   min-height: 45px;
   padding: 22px 0 0; }
   @media (max-width: 1200px) {
-    /* line 30, ../scss/components/_soe_dm_brand_bar.scss */
     .node-type-stanford-collection #header.header,
     .node-type-stanford-magazine-issue #header.header,
     .page-taxonomy-term #header.header,
@@ -2856,7 +2527,6 @@ p.infotext {
       min-height: 29px;
       padding: 16px 0 0; } }
   @media (max-width: 767px) {
-    /* line 30, ../scss/components/_soe_dm_brand_bar.scss */
     .node-type-stanford-collection #header.header,
     .node-type-stanford-magazine-issue #header.header,
     .page-taxonomy-term #header.header,
@@ -2865,7 +2535,6 @@ p.infotext {
     .node-type-stanford-magazine-article #header.header {
       padding: 10px 0 0; } }
   @media (max-width: 400px) {
-    /* line 30, ../scss/components/_soe_dm_brand_bar.scss */
     .node-type-stanford-collection #header.header,
     .node-type-stanford-magazine-issue #header.header,
     .page-taxonomy-term #header.header,
@@ -2874,7 +2543,6 @@ p.infotext {
     .node-type-stanford-magazine-article #header.header {
       min-height: auto; } }
   @media (max-width: 480px) {
-    /* line 48, ../scss/components/_soe_dm_brand_bar.scss */
     .node-type-stanford-collection #header.header #site-title-first-line.site-title-uppercase a,
     .node-type-stanford-magazine-issue #header.header #site-title-first-line.site-title-uppercase a,
     .page-taxonomy-term #header.header #site-title-first-line.site-title-uppercase a,
@@ -2884,7 +2552,6 @@ p.infotext {
       font-size: 28px;
       margin-bottom: -5px; } }
   @media (max-width: 400px) {
-    /* line 48, ../scss/components/_soe_dm_brand_bar.scss */
     .node-type-stanford-collection #header.header #site-title-first-line.site-title-uppercase a,
     .node-type-stanford-magazine-issue #header.header #site-title-first-line.site-title-uppercase a,
     .page-taxonomy-term #header.header #site-title-first-line.site-title-uppercase a,
@@ -2894,7 +2561,6 @@ p.infotext {
       font-size: 18px;
       margin-bottom: -3px; } }
   @media (max-width: 380px) {
-    /* line 48, ../scss/components/_soe_dm_brand_bar.scss */
     .node-type-stanford-collection #header.header #site-title-first-line.site-title-uppercase a,
     .node-type-stanford-magazine-issue #header.header #site-title-first-line.site-title-uppercase a,
     .page-taxonomy-term #header.header #site-title-first-line.site-title-uppercase a,
@@ -2903,7 +2569,7 @@ p.infotext {
     .node-type-stanford-magazine-article #header.header #site-title-first-line.site-title-uppercase a {
       font-size: 16px;
       margin-bottom: -4px; } }
-/* line 64, ../scss/components/_soe_dm_brand_bar.scss */
+
 .node-type-stanford-collection #header #site-title-first-line.site-title-uppercase,
 .node-type-stanford-magazine-issue #header #site-title-first-line.site-title-uppercase,
 .page-taxonomy-term #header #site-title-first-line.site-title-uppercase,
@@ -2912,8 +2578,8 @@ p.infotext {
 .node-type-stanford-magazine-article #header #site-title-first-line.site-title-uppercase {
   font-size: 18px;
   margin-bottom: -3px; }
+
 @media (max-width: 480px) {
-  /* line 69, ../scss/components/_soe_dm_brand_bar.scss */
   .node-type-stanford-collection #header #name-and-slogan.with-logo,
   .node-type-stanford-magazine-issue #header #name-and-slogan.with-logo,
   .page-taxonomy-term #header #name-and-slogan.with-logo,
@@ -2922,52 +2588,41 @@ p.infotext {
   .node-type-stanford-magazine-article #header #name-and-slogan.with-logo {
     padding: 0 0 0 5px; } }
 
-/* line 12, ../scss/components/_soe_dm_collection.scss */
 .view-stanford-magazine-collection-list .views-row {
   margin-bottom: 80px; }
   @media (max-width: 480px) {
-    /* line 12, ../scss/components/_soe_dm_collection.scss */
     .view-stanford-magazine-collection-list .views-row {
       margin-bottom: 20px; } }
-  /* line 18, ../scss/components/_soe_dm_collection.scss */
   .view-stanford-magazine-collection-list .views-row:nth-child(3n+1) a {
     -webkit-text-decoration-color: #FFBD54;
     text-decoration-color: #FFBD54; }
-    /* line 21, ../scss/components/_soe_dm_collection.scss */
     .view-stanford-magazine-collection-list .views-row:nth-child(3n+1) a:focus, .view-stanford-magazine-collection-list .views-row:nth-child(3n+1) a:hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
-  /* line 26, ../scss/components/_soe_dm_collection.scss */
   .view-stanford-magazine-collection-list .views-row:nth-child(3n+1) .collection-img {
     background-color: #FFBD54; }
-  /* line 31, ../scss/components/_soe_dm_collection.scss */
   .view-stanford-magazine-collection-list .views-row:nth-child(3n+2) a {
     -webkit-text-decoration-color: #FF525C;
     text-decoration-color: #FF525C; }
-    /* line 34, ../scss/components/_soe_dm_collection.scss */
     .view-stanford-magazine-collection-list .views-row:nth-child(3n+2) a:focus, .view-stanford-magazine-collection-list .views-row:nth-child(3n+2) a:hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
-  /* line 39, ../scss/components/_soe_dm_collection.scss */
   .view-stanford-magazine-collection-list .views-row:nth-child(3n+2) .collection-img {
     background-color: #FF525C; }
-  /* line 44, ../scss/components/_soe_dm_collection.scss */
   .view-stanford-magazine-collection-list .views-row:nth-child(3n) a {
     -webkit-text-decoration-color: #00ECE9;
     text-decoration-color: #00ECE9; }
-    /* line 47, ../scss/components/_soe_dm_collection.scss */
     .view-stanford-magazine-collection-list .views-row:nth-child(3n) a:focus, .view-stanford-magazine-collection-list .views-row:nth-child(3n) a:hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
-  /* line 52, ../scss/components/_soe_dm_collection.scss */
   .view-stanford-magazine-collection-list .views-row:nth-child(3n) .collection-img {
     background-color: #00ECE9; }
-/* line 58, ../scss/components/_soe_dm_collection.scss */
+
 .view-stanford-magazine-collection-list .collection-date {
   color: #606060;
   font-size: 0.9em;
   font-weight: 100; }
-/* line 63, ../scss/components/_soe_dm_collection.scss */
+
 .view-stanford-magazine-collection-list .collection-content-container {
   position: relative;
   background: #FFFFFF;
@@ -2975,72 +2630,61 @@ p.infotext {
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-/* line 72, ../scss/components/_soe_dm_collection.scss */
+
 .view-stanford-magazine-collection-list .collection-title {
   font-size: 1.3em;
   line-height: 1.3em; }
-  /* line 75, ../scss/components/_soe_dm_collection.scss */
   .view-stanford-magazine-collection-list .collection-title a {
     color: #333333;
     font-weight: 600;
     text-decoration: underline;
     text-decoration-skip: ink; }
-    /* line 80, ../scss/components/_soe_dm_collection.scss */
     .view-stanford-magazine-collection-list .collection-title a:focus, .view-stanford-magazine-collection-list .collection-title a:hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
-/* line 86, ../scss/components/_soe_dm_collection.scss */
+
 .view-stanford-magazine-collection-list .collection-img {
   height: 130px; }
-/* line 91, ../scss/components/_soe_dm_collection.scss */
+
 .view-stanford-magazine-collection-list.most-recent-collection .collection-container {
   display: flex;
   margin: 40px 0 80px; }
   @media (max-width: 480px) {
-    /* line 91, ../scss/components/_soe_dm_collection.scss */
     .view-stanford-magazine-collection-list.most-recent-collection .collection-container {
       margin-bottom: 0; } }
-  /* line 99, ../scss/components/_soe_dm_collection.scss */
   .view-stanford-magazine-collection-list.most-recent-collection .collection-container .collection-title a {
     -webkit-text-decoration-color: #00ECE9;
     text-decoration-color: #00ECE9; }
-    /* line 102, ../scss/components/_soe_dm_collection.scss */
     .view-stanford-magazine-collection-list.most-recent-collection .collection-container .collection-title a:focus, .view-stanford-magazine-collection-list.most-recent-collection .collection-container .collection-title a:hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
-  /* line 108, ../scss/components/_soe_dm_collection.scss */
   .view-stanford-magazine-collection-list.most-recent-collection .collection-container .collection-img {
     width: 45%;
     height: 260px;
     background-color: #00ECE9; }
-  /* line 113, ../scss/components/_soe_dm_collection.scss */
   .view-stanford-magazine-collection-list.most-recent-collection .collection-container .collection-content-container {
     width: 55%;
     height: auto; }
 
-/* line 122, ../scss/components/_soe_dm_collection.scss */
 .node-type-stanford-collection #content-body-bottom {
   margin-top: 5%; }
-/* line 126, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-collection #mc_embed_signup_scroll {
   padding-top: 100px;
   padding-bottom: 100px; }
-/* line 131, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-collection .main {
   padding: 0; }
 
-/* line 143, ../scss/components/_soe_dm_collection.scss */
 .node-type-stanford-magazine-article .main {
   padding: 80px 0 0; }
-/* line 147, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-magazine-article .view-display-id-article_collection {
   padding-bottom: 40px;
   padding-top: 40px;
   background-color: #e4e4e4; }
-  /* line 152, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-magazine-article .view-display-id-article_collection .views-row {
     margin-bottom: 0; }
-  /* line 156, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-magazine-article .view-display-id-article_collection .views-field-field-s-collectlon-intro-label {
     color: #606060;
     font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -3050,7 +2694,6 @@ p.infotext {
     line-height: 1.3em;
     margin-bottom: 20px;
     text-align: center; }
-  /* line 167, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-magazine-article .view-display-id-article_collection .mag-collection-title {
     color: #000000;
     font-family: "Roboto Slab", serif;
@@ -3059,32 +2702,25 @@ p.infotext {
     letter-spacing: 0;
     text-align: center; }
     @media (max-width: 767px) {
-      /* line 167, ../scss/components/_soe_dm_collection.scss */
       .node-type-stanford-magazine-article .view-display-id-article_collection .mag-collection-title {
         line-height: 1em; } }
-    /* line 179, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-magazine-article .view-display-id-article_collection .mag-collection-title[class*="mag-collection-color-"] a {
       color: #333333;
       text-decoration: underline;
       -webkit-text-decoration-skip: ink;
       text-decoration-skip: ink; }
-      /* line 184, ../scss/components/_soe_dm_collection.scss */
       .node-type-stanford-magazine-article .view-display-id-article_collection .mag-collection-title[class*="mag-collection-color-"] a:focus, .node-type-stanford-magazine-article .view-display-id-article_collection .mag-collection-title[class*="mag-collection-color-"] a:hover {
         -webkit-text-decoration-color: #333333;
         text-decoration-color: #333333; }
-    /* line 190, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-magazine-article .view-display-id-article_collection .mag-collection-title.mag-collection-color-orange a {
       -webkit-text-decoration-color: #FFBD54;
       text-decoration-color: #FFBD54; }
-    /* line 194, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-magazine-article .view-display-id-article_collection .mag-collection-title.mag-collection-color-turquoise a {
       -webkit-text-decoration-color: #00ECE9;
       text-decoration-color: #00ECE9; }
-    /* line 198, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-magazine-article .view-display-id-article_collection .mag-collection-title.mag-collection-color-pink a {
       -webkit-text-decoration-color: #FF525C;
       text-decoration-color: #FF525C; }
-  /* line 203, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-magazine-article .view-display-id-article_collection .views-field-field-s-collection-subtitle {
     color: #606060;
     font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -3094,30 +2730,27 @@ p.infotext {
     font-size: 20px;
     padding: 0 20px;
     text-align: center; }
+
 @media (max-width: 580px) {
-  /* line 216, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-magazine-article .view-stanford-magazine-article-collection .views-field-field-s-collection-cont-label {
     font-size: 14px; } }
+
 @media (max-width: 580px) {
-  /* line 222, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-magazine-article .view-stanford-magazine-article-collection .views-field-title {
     font-size: 18px; } }
+
 @media (max-width: 580px) {
-  /* line 228, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-magazine-article .view-stanford-magazine-article-collection .views-field-field-s-collection-subtitle {
     font-size: 16px; } }
-/* line 234, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block {
   background-color: #EFEFEF;
   padding: 0 15% 80px; }
-  /* line 238, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block .view-header {
     margin-bottom: 80px; }
     @media (max-width: 580px) {
-      /* line 238, ../scss/components/_soe_dm_collection.scss */
       .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block .view-header {
         margin-bottom: 40px; } }
-    /* line 245, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block .view-header .views-field-field-s-collection-cont-label {
       color: #606060;
       font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -3129,10 +2762,8 @@ p.infotext {
       padding-top: 40px;
       text-align: center; }
       @media (max-width: 580px) {
-        /* line 245, ../scss/components/_soe_dm_collection.scss */
         .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block .view-header .views-field-field-s-collection-cont-label {
           font-size: 14px; } }
-    /* line 261, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block .view-header .views-field-title {
       color: #333333;
       font-family: "Roboto Slab", serif;
@@ -3143,11 +2774,9 @@ p.infotext {
       margin-bottom: 4px;
       text-align: center; }
       @media (max-width: 580px) {
-        /* line 261, ../scss/components/_soe_dm_collection.scss */
         .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block .view-header .views-field-title {
           font-size: 18px;
           line-height: 1em; } }
-    /* line 277, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block .view-header .views-field-field-s-collection-subtitle {
       color: #606060;
       font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -3158,13 +2787,10 @@ p.infotext {
       padding: 0 20px;
       text-align: center; }
       @media (max-width: 580px) {
-        /* line 277, ../scss/components/_soe_dm_collection.scss */
         .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block .view-header .views-field-field-s-collection-subtitle {
           font-size: 16px; } }
-  /* line 293, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block .view-footer {
     text-align: center; }
-    /* line 296, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block .view-footer a {
       background: #B1040E;
       border-radius: 0;
@@ -3178,51 +2804,43 @@ p.infotext {
       line-height: 1.4em;
       letter-spacing: 0.03em;
       margin: 0 0 80px; }
-      /* line 310, ../scss/components/_soe_dm_collection.scss */
       .node-type-stanford-magazine-article .view-stanford-magazine-article-collection.view-display-id-article_collection_bottom_block .view-footer a:hover {
         background: #333333; }
 
-/* line 326, ../scss/components/_soe_dm_collection.scss */
 .node-type-stanford-collection #content-head {
   display: block;
   margin-bottom: 0; }
-/* line 331, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-collection #mc_embed_signup_scroll {
   padding: 0; }
-/* line 336, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-collection .mailchimp-magazine-block #mc_embed_signup_scroll {
   box-shadow: none;
   -webkit-box-shadow: none;
   padding: 65px 0; }
   @media (max-width: 767px) {
-    /* line 336, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-collection .mailchimp-magazine-block #mc_embed_signup_scroll {
       padding: 40px 0; } }
-/* line 348, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-collection form#mc-embedded-subscribe-form {
   margin-bottom: 0; }
-/* line 353, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-collection #main {
   padding-bottom: 80px;
   padding-top: 80px;
   background-color: #EFEFEF; }
   @media (max-width: 767px) {
-    /* line 353, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-collection #main {
       padding: 40px 0; } }
-  /* line 361, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-collection #main .mc-content {
     margin: 0; }
-    /* line 363, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-collection #main .mc-content .title {
       margin: 0 0 10px;
       text-align: center;
       line-height: 1.2em; }
       @media (max-width: 767px) {
-        /* line 363, ../scss/components/_soe_dm_collection.scss */
         .node-type-stanford-collection #main .mc-content .title {
           line-height: 1em; } }
-    /* line 373, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-collection #main .mc-content .field-name-field-s-collection-subtitle {
       color: #606060;
       font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -3234,18 +2852,15 @@ p.infotext {
       text-align: center;
       width: 70%; }
       @media (max-width: 767px) {
-        /* line 373, ../scss/components/_soe_dm_collection.scss */
         .node-type-stanford-collection #main .mc-content .field-name-field-s-collection-subtitle {
           font-size: 1.2em;
           width: 85%;
           margin: 0 auto; } }
       @media (max-width: 480px) {
-        /* line 373, ../scss/components/_soe_dm_collection.scss */
         .node-type-stanford-collection #main .mc-content .field-name-field-s-collection-subtitle {
           font-size: 1em;
           width: 100%;
           margin: 0 auto; } }
-    /* line 395, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-collection #main .mc-content .field-name-field-s-collection-lead-text {
       color: #606060;
       font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -3256,37 +2871,32 @@ p.infotext {
       width: 70%;
       margin: 30px auto 0; }
       @media (max-width: 767px) {
-        /* line 395, ../scss/components/_soe_dm_collection.scss */
         .node-type-stanford-collection #main .mc-content .field-name-field-s-collection-lead-text {
           font-size: 1em;
           width: 85%;
           margin: 20px auto 0; } }
       @media (max-width: 480px) {
-        /* line 395, ../scss/components/_soe_dm_collection.scss */
         .node-type-stanford-collection #main .mc-content .field-name-field-s-collection-lead-text {
           font-size: .9em;
           width: 100%;
           margin: 10px auto 0; } }
-/* line 419, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-collection .view-display-id-collection_group_block_1 .views-row {
   margin: 80px 0; }
   @media (max-width: 580px) {
-    /* line 419, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-collection .view-display-id-collection_group_block_1 .views-row {
       margin: 40px 0; } }
-/* line 427, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-img {
   width: 45%;
   float: left; }
   @media (max-width: 1200px) {
-    /* line 427, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-img {
       width: 41%; } }
   @media (max-width: 979px) {
-    /* line 427, ../scss/components/_soe_dm_collection.scss */
     .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-img {
       width: 100%; } }
-/* line 440, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-container {
   background: #FFFFFF;
   float: left;
@@ -3295,7 +2905,6 @@ p.infotext {
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 449, ../scss/components/_soe_dm_collection.scss */
   .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-container .mag-article-content-container {
     float: left;
     width: 49%;
@@ -3303,25 +2912,21 @@ p.infotext {
     -moz-box-shadow: none;
     box-shadow: none; }
     @media (max-width: 1200px) {
-      /* line 449, ../scss/components/_soe_dm_collection.scss */
       .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-container .mag-article-content-container {
         min-height: auto;
         width: 52%; }
-        /* line 460, ../scss/components/_soe_dm_collection.scss */
         .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-container .mag-article-content-container .mag-article-topics {
           margin: 20px 0 0 !important; } }
     @media (max-width: 979px) {
-      /* line 449, ../scss/components/_soe_dm_collection.scss */
       .node-type-stanford-collection .view-display-id-collection_group_block_1 .mag-article-container .mag-article-content-container {
         width: auto; } }
-/* line 471, ../scss/components/_soe_dm_collection.scss */
+
 .node-type-stanford-collection .view-display-id-collection_group_block_1 .edit-link {
   float: left;
   margin-bottom: 20px;
   width: 100%; }
 
 @media (max-width: 767px) {
-  /* line 16, ../scss/components/_soe_dm_navigation.scss */
   .node-type-stanford-collection .navbar .btn.btn-navbar,
   .page-taxonomy-term .navbar .btn.btn-navbar,
   .node-type-stanford-magazine-issue .navbar .btn.btn-navbar,
@@ -3331,8 +2936,8 @@ p.infotext {
     background: #B1040E;
     margin-top: -29px;
     float: right; } }
+
 @media (max-width: 480px) {
-  /* line 16, ../scss/components/_soe_dm_navigation.scss */
   .node-type-stanford-collection .navbar .btn.btn-navbar,
   .page-taxonomy-term .navbar .btn.btn-navbar,
   .node-type-stanford-magazine-issue .navbar .btn.btn-navbar,
@@ -3341,54 +2946,42 @@ p.infotext {
   .node-type-stanford-magazine-article .navbar .btn.btn-navbar {
     margin-top: -29px; } }
 
-/* line 31, ../scss/components/_soe_dm_navigation.scss */
 #digital-magazine-menu {
   background: #00ECE9; }
   @media (max-width: 767px) {
-    /* line 34, ../scss/components/_soe_dm_navigation.scss */
     #digital-magazine-menu .container {
       width: auto;
       margin: 0 20px; } }
-  /* line 41, ../scss/components/_soe_dm_navigation.scss */
   #digital-magazine-menu .region-digital-magazine-menu {
     display: flex;
     justify-content: center; }
     @media (max-width: 979px) {
-      /* line 41, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-menu .region-digital-magazine-menu {
         flex-wrap: wrap; } }
     @media (max-width: 767px) {
-      /* line 41, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-menu .region-digital-magazine-menu {
         flex-wrap: nowrap; } }
     @media (min-width: 1200px) {
-      /* line 41, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-menu .region-digital-magazine-menu {
         margin-left: 74px; } }
-    /* line 54, ../scss/components/_soe_dm_navigation.scss */
     #digital-magazine-menu .region-digital-magazine-menu .block-menu-block {
       display: flex;
       align-items: center;
       justify-content: center;
       padding-top: 20px; }
       @media (max-width: 767px) {
-        /* line 54, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-menu .region-digital-magazine-menu .block-menu-block {
           display: block;
           width: 100%; } }
-      /* line 64, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2 {
         margin-bottom: 0;
         padding-bottom: 20px; }
         @media (max-width: 767px) {
-          /* line 64, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2 {
             float: left; } }
-        /* line 71, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2 a {
           font-weight: 600;
           text-decoration: none; }
-        /* line 76, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2:after {
           content: "|";
           font-size: 1.3125em;
@@ -3396,36 +2989,27 @@ p.infotext {
           padding: 0 30px;
           vertical-align: top; }
           @media (max-width: 767px) {
-            /* line 76, ../scss/components/_soe_dm_navigation.scss */
             #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2:after {
               content: none; } }
-      /* line 88, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul {
         margin-bottom: 0; }
-        /* line 91, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li {
           font-weight: 600;
           display: inline;
           float: left;
           list-style: none; }
-          /* line 97, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.collapsed, #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.expanded, #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.leaf {
             padding: 10px 20px 0 0; }
-          /* line 103, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li:first-child {
             margin-left: 0; }
             @media (max-width: 767px) {
-              /* line 103, ../scss/components/_soe_dm_navigation.scss */
               #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li:first-child {
                 float: right; } }
-          /* line 110, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li:last-child {
             margin-bottom: 0; }
           @media (max-width: 767px) {
-            /* line 114, ../scss/components/_soe_dm_navigation.scss */
             #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li:nth-child(2) {
               display: none; } }
-          /* line 121, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.first.leaf a:after {
             content: "";
             background-image: url("../img/soe_chevron_down_black.svg");
@@ -3435,115 +3019,97 @@ p.infotext {
             padding-left: 18px;
             margin-left: 12px; }
             @media (max-width: 767px) {
-              /* line 121, ../scss/components/_soe_dm_navigation.scss */
               #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.first.leaf a:after {
                 content: "\00a0 \00a0 \00a0 |"; } }
-          /* line 134, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.first.leaf a:hover:after {
             background-image: url("../img/soe_chevron_down_gray-orange.svg"); }
-          /* line 138, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li.first.leaf a:focus:after {
             background-image: url("../img/soe_chevron_up_gray-orange.svg"); }
-          /* line 143, ../scss/components/_soe_dm_navigation.scss */
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a {
             color: #333333;
             padding-bottom: 20px;
             border-bottom: 2px solid transparent;
             font-weight: 600; }
-            /* line 149, ../scss/components/_soe_dm_navigation.scss */
             #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a:focus, #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a:hover {
               color: #606060;
               background-color: transparent;
               border-bottom-color: #606060; }
-            /* line 156, ../scss/components/_soe_dm_navigation.scss */
             #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a.active {
               color: #606060;
               border-bottom-color: #606060; }
-    /* line 166, ../scss/components/_soe_dm_navigation.scss */
     #digital-magazine-menu .region-digital-magazine-menu .block-stanford-search-api .form-item-keywords {
       margin-top: 1.1em; }
       @media (max-width: 767px) {
-        /* line 166, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-menu .region-digital-magazine-menu .block-stanford-search-api .form-item-keywords {
           margin-top: 26px; } }
 
-/* line 180, ../scss/components/_soe_dm_navigation.scss */
 #digital-magazine-megamenu .container {
   background-color: #575757; }
-  /* line 184, ../scss/components/_soe_dm_navigation.scss */
   #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content {
     display: flex;
     flex-wrap: wrap;
     text-align: center; }
-    /* line 189, ../scss/components/_soe_dm_navigation.scss */
     #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row {
       width: calc(100% * (1/4) - 2%);
       margin-right: 2%; }
       @media (max-width: 767px) {
-        /* line 189, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row {
           width: calc(100% * (1/2) - 2%); } }
       @media (max-width: 480px) {
-        /* line 189, ../scss/components/_soe_dm_navigation.scss */
         #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row {
           width: 100%; } }
-      /* line 199, ../scss/components/_soe_dm_navigation.scss */
       #digital-magazine-megamenu .container .region-digital-magazine-megamenu .view-content .views-row a {
         color: #FFFFFF;
         font-size: 1em; }
 
-/* line 210, ../scss/components/_soe_dm_navigation.scss */
 #main-menu .navbar {
   margin-bottom: 0; }
-  /* line 215, ../scss/components/_soe_dm_navigation.scss */
-  .node-type-stanford-collection #main-menu .navbar .nav > li > a, .page-taxonomy-term #main-menu .navbar .nav > li > a, .node-type-stanford-magazine-issue #main-menu .navbar .nav > li > a, .page-magazine #main-menu .navbar .nav > li > a,
-  #main-menu .navbar .nav > li > a .page-magazine-all, .node-type-stanford-magazine-article #main-menu .navbar .nav > li > a {
+  .node-type-stanford-collection #main-menu .navbar .nav > li > a,
+  .page-taxonomy-term #main-menu .navbar .nav > li > a,
+  .node-type-stanford-magazine-issue #main-menu .navbar .nav > li > a,
+  .page-magazine #main-menu .navbar .nav > li > a,
+  #main-menu .navbar .nav > li > a .page-magazine-all,
+  .node-type-stanford-magazine-article #main-menu .navbar .nav > li > a {
     padding-bottom: 15px; }
     @media (max-width: 1200px) {
-      /* line 215, ../scss/components/_soe_dm_navigation.scss */
-      .node-type-stanford-collection #main-menu .navbar .nav > li > a, .page-taxonomy-term #main-menu .navbar .nav > li > a, .node-type-stanford-magazine-issue #main-menu .navbar .nav > li > a, .page-magazine #main-menu .navbar .nav > li > a,
-      #main-menu .navbar .nav > li > a .page-magazine-all, .node-type-stanford-magazine-article #main-menu .navbar .nav > li > a {
+      .node-type-stanford-collection #main-menu .navbar .nav > li > a,
+      .page-taxonomy-term #main-menu .navbar .nav > li > a,
+      .node-type-stanford-magazine-issue #main-menu .navbar .nav > li > a,
+      .page-magazine #main-menu .navbar .nav > li > a,
+      #main-menu .navbar .nav > li > a .page-magazine-all,
+      .node-type-stanford-magazine-article #main-menu .navbar .nav > li > a {
         padding-bottom: 9px; } }
 
-/* line 8, ../scss/components/_soe_dm_search.scss */
 #digital-magazine-menu.soe-mobile-search-active {
   background: #b1fffe; }
-  /* line 11, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu.soe-mobile-search-active .block-stanford-search-api {
     background: #b1fffe;
     width: 100%;
     z-index: 9999;
     position: absolute;
     left: 0; }
-    /* line 18, ../scss/components/_soe_dm_search.scss */
     #digital-magazine-menu.soe-mobile-search-active .block-stanford-search-api .dm-search-close {
       float: right;
       margin-top: -55px;
       padding-right: 20px; }
-    /* line 24, ../scss/components/_soe_dm_search.scss */
     #digital-magazine-menu.soe-mobile-search-active .block-stanford-search-api .form-item {
       margin-top: 22px; }
-/* line 30, ../scss/components/_soe_dm_search.scss */
+
 #digital-magazine-menu .block-stanford-search-api {
   position: relative; }
   @media (max-width: 979px) {
-    /* line 30, ../scss/components/_soe_dm_search.scss */
     #digital-magazine-menu .block-stanford-search-api {
       display: flex; } }
   @media (max-width: 767px) {
-    /* line 30, ../scss/components/_soe_dm_search.scss */
     #digital-magazine-menu .block-stanford-search-api {
       display: block;
       width: auto; } }
-  /* line 40, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu .block-stanford-search-api h2,
   #digital-magazine-menu .block-stanford-search-api input.btn-search {
     display: none; }
   @media (max-width: 767px) {
-    /* line 45, ../scss/components/_soe_dm_search.scss */
     #digital-magazine-menu .block-stanford-search-api .form-item {
       margin-top: 26px; } }
-  /* line 51, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu .block-stanford-search-api input[type="text"] {
     font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 1em;
@@ -3555,72 +3121,57 @@ p.infotext {
     padding: 8px 0 0 40px;
     background: url("../img/soe_mag_glass_black.svg") no-repeat 6% 70%; }
     @media (max-width: 767px) {
-      /* line 51, ../scss/components/_soe_dm_search.scss */
       #digital-magazine-menu .block-stanford-search-api input[type="text"] {
         padding-top: 0; }
-        /* line 64, ../scss/components/_soe_dm_search.scss */
         #digital-magazine-menu .block-stanford-search-api input[type="text"]:focus {
           padding-top: 10px; } }
-    /* line 69, ../scss/components/_soe_dm_search.scss */
     .not-logged-in #digital-magazine-menu .block-stanford-search-api input[type="text"] {
       margin-right: -15px; }
-  /* line 74, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu .block-stanford-search-api .input-medium {
     width: 175px; }
     @media (max-width: 979px) {
-      /* line 74, ../scss/components/_soe_dm_search.scss */
       #digital-magazine-menu .block-stanford-search-api .input-medium {
         width: 115px; } }
     @media (max-width: 767px) {
-      /* line 74, ../scss/components/_soe_dm_search.scss */
       #digital-magazine-menu .block-stanford-search-api .input-medium {
         width: 0; }
-        /* line 82, ../scss/components/_soe_dm_search.scss */
         #digital-magazine-menu .block-stanford-search-api .input-medium:focus {
           width: 250px; } }
-  /* line 88, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu .block-stanford-search-api input:-ms-input-placeholder {
     color: #333333; }
-  /* line 92, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu .block-stanford-search-api input::-moz-placeholder {
     color: #333333;
     opacity: 1; }
-  /* line 97, ../scss/components/_soe_dm_search.scss */
   #digital-magazine-menu .block-stanford-search-api input::-webkit-input-placeholder {
     color: #333333; }
 
-/* line 11, ../scss/components/_soe_dm_article.scss */
 .node-type-stanford-magazine-article h1 {
   width: 85%;
   margin: 0 auto; }
-/* line 16, ../scss/components/_soe_dm_article.scss */
+
 .node-type-stanford-magazine-article .field-name-field-s-mag-article-topics {
   font-size: 1em;
   margin: 0 auto 18px;
   width: 65%; }
   @media (max-width: 979px) {
-    /* line 16, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .field-name-field-s-mag-article-topics {
       width: 85%; } }
   @media (max-width: 480px) {
-    /* line 16, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .field-name-field-s-mag-article-topics {
       width: 100%; } }
-/* line 28, ../scss/components/_soe_dm_article.scss */
+
 .node-type-stanford-magazine-article .field-name-field-s-mag-article-dek {
   font-size: 1.3em;
   line-height: 1.3em;
   margin: 44px auto 22px;
   width: 65%; }
   @media (max-width: 979px) {
-    /* line 28, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .field-name-field-s-mag-article-dek {
       width: 85%; } }
   @media (max-width: 480px) {
-    /* line 28, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .field-name-field-s-mag-article-dek {
       width: 100%; } }
-/* line 41, ../scss/components/_soe_dm_article.scss */
+
 .node-type-stanford-magazine-article .group-s-mag-article-date-byline {
   width: 65%;
   font-size: 0.9em;
@@ -3630,207 +3181,163 @@ p.infotext {
   justify-content: space-between;
   margin: 0 auto 32px; }
   @media (max-width: 979px) {
-    /* line 41, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .group-s-mag-article-date-byline {
       width: 85%; } }
   @media (max-width: 480px) {
-    /* line 41, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .group-s-mag-article-date-byline {
       width: 100%; } }
-  /* line 57, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-date-and-byline,
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print {
     display: flex;
     flex-wrap: wrap;
     height: auto; }
-  /* line 64, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-date-and-byline {
     width: 70%; }
     @media (max-width: 480px) {
-      /* line 64, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-date-and-byline {
         width: 100%; } }
-    /* line 71, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-date-and-byline .field-name-field-s-mag-article-date,
     .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-date-and-byline .field-name-field-s-mag-article-byline {
       margin-bottom: 0; }
-  /* line 77, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print {
     width: 30%; }
     @media (max-width: 979px) {
-      /* line 77, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print {
         width: 50%;
         margin-left: -13px; } }
     @media (max-width: 480px) {
-      /* line 77, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print {
         width: 100%; } }
-  /* line 90, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-date .field-item:after {
     content: "\00a0 \00a0 |\00a0 \00a0 "; }
-  /* line 97, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-collection .field-label {
     font-family: Source sans pro;
     font-size: 18px;
     font-weight: 400;
     line-height: 1.2em; }
-    /* line 103, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-collection .field-label::after {
       content: "\00a0"; }
     @media (max-width: 979px) {
-      /* line 97, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-collection .field-label {
         font-size: 17px; } }
     @media (max-width: 767px) {
-      /* line 97, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-collection .field-label {
         font-size: 16.5px; } }
     @media (max-width: 580px) {
-      /* line 97, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-collection .field-label {
         font-size: 16.1px; } }
     @media (max-width: 400px) {
-      /* line 97, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-collection .field-label {
         font-size: 15px; } }
-  /* line 121, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-collection .field-items {
     font-family: "Roboto Slab", serif;
     font-size: .95em;
     font-weight: bold;
     line-height: 1.2em;
     margin-top: 1px; }
-    /* line 128, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-collection .field-items a.orange {
       color: #000000;
       text-decoration: underline;
       text-decoration-color: #FFBD54;
       -webkit-text-decoration-color: #FFBD54;
       text-decoration-color: #FFBD54; }
-      /* line 134, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-collection .field-items a.orange:hover {
         content: "\00a0 \00a0 |\00a0 \00a0 "; }
-    /* line 139, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-collection .field-items a.pink {
       color: #000000;
       text-decoration: underline;
       text-decoration-color: #FF525C;
       -webkit-text-decoration-color: #FF525C;
       text-decoration-color: #FF525C; }
-    /* line 146, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .group-s-mag-article-date-byline .field-name-field-s-mag-article-collection .field-items a.turquoise {
       color: #000000;
       text-decoration: underline;
       text-decoration-color: #00ECE9;
       -webkit-text-decoration-color: #00ECE9;
       text-decoration-color: #00ECE9; }
-  /* line 156, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print a {
     margin-right: 10px; }
-  /* line 160, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print .widget-wrapper-fb,
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print .widget-wrapper-twitter {
     margin-right: -8px; }
-  /* line 168, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print .widget-wrapper-fb img,
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print .widget-wrapper-linkedin img,
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print .widget-wrapper-twitter img {
     width: auto;
     height: 40px;
     margin-right: -10px; }
-  /* line 175, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print .field-name-forward-ds-field {
     margin-top: 8px;
     margin-bottom: 0; }
-    /* line 179, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print .field-name-forward-ds-field a {
       font-size: 0em;
       color: transparent; }
-      /* line 183, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print .field-name-forward-ds-field a:after {
         content: url("../modules/stanford_soe_helper_magazine/img/soe_forward_icon_gray.svg"); }
-  /* line 189, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print .field-name-field-s-mag-article-print {
     margin-top: 6px;
     margin-bottom: 0; }
-    /* line 193, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print .field-name-field-s-mag-article-print a {
       font-size: 0em;
       color: transparent;
       margin-right: 0; }
-      /* line 198, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article .group-s-mag-article-date-byline .group-s-social-and-print .field-name-field-s-mag-article-print a:after {
         content: url("../modules/stanford_soe_helper_magazine/img/soe_print_icon_gray.svg"); }
-/* line 207, ../scss/components/_soe_dm_article.scss */
+
 .node-type-stanford-magazine-article .field-name-body iframe {
   width: 100%;
   height: 550px; }
-  /* line 210, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .field-name-body iframe.iframe-auto {
     height: auto; }
-/* line 218, ../scss/components/_soe_dm_article.scss */
+
 .node-type-stanford-magazine-article #block-bean-stanford-soe-mag-news-signup .mailchimp-magazine-block #mc_embed_signup_scroll {
   width: 50%;
   margin: 0 auto; }
-  /* line 222, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article #block-bean-stanford-soe-mag-news-signup .mailchimp-magazine-block #mc_embed_signup_scroll h2 {
     font-size: 1.3em;
     margin-bottom: 20px; }
     @media (max-width: 480px) {
-      /* line 222, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article #block-bean-stanford-soe-mag-news-signup .mailchimp-magazine-block #mc_embed_signup_scroll h2 {
         font-size: 1.1em; } }
-  /* line 232, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article #block-bean-stanford-soe-mag-news-signup .mailchimp-magazine-block #mc_embed_signup_scroll .mc-field-group input {
     width: 300px; }
     @media (max-width: 580px) {
-      /* line 232, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article #block-bean-stanford-soe-mag-news-signup .mailchimp-magazine-block #mc_embed_signup_scroll .mc-field-group input {
         width: 200px; } }
     @media (max-width: 480px) {
-      /* line 232, ../scss/components/_soe_dm_article.scss */
       .node-type-stanford-magazine-article #block-bean-stanford-soe-mag-news-signup .mailchimp-magazine-block #mc_embed_signup_scroll .mc-field-group input {
         width: 150px; } }
   @media (max-width: 979px) {
-    /* line 218, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article #block-bean-stanford-soe-mag-news-signup .mailchimp-magazine-block #mc_embed_signup_scroll {
       width: 70%; } }
   @media (max-width: 480px) {
-    /* line 218, ../scss/components/_soe_dm_article.scss */
     .node-type-stanford-magazine-article #block-bean-stanford-soe-mag-news-signup .mailchimp-magazine-block #mc_embed_signup_scroll {
       width: 80%;
       padding: 25px; } }
 
-/* line 260, ../scss/components/_soe_dm_article.scss */
 .page-magazine-all #page-title,
 .page-taxonomy-term #page-title {
   text-align: center; }
 
-/* line 266, ../scss/components/_soe_dm_article.scss */
 #block-views-a06b957e34c741c20a352da1b7ce0e12 h2 {
   text-align: center;
   margin: 2em 0 1.5em; }
-/* line 271, ../scss/components/_soe_dm_article.scss */
+
 #block-views-a06b957e34c741c20a352da1b7ce0e12 .article-grouping {
   padding: 0 70px; }
   @media (max-width: 979px) {
-    /* line 271, ../scss/components/_soe_dm_article.scss */
     #block-views-a06b957e34c741c20a352da1b7ce0e12 .article-grouping {
       padding: 0px; } }
 
-/* line 282, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-most-recent.most-recent-article,
 .view-stanford-magazine-articles.most-recent-article,
 .view-stanford-magazine-topics.most-recent-article {
   margin: 40px 0 80px; }
   @media (max-width: 480px) {
-    /* line 282, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.most-recent-article,
     .view-stanford-magazine-articles.most-recent-article,
     .view-stanford-magazine-topics.most-recent-article {
       margin-bottom: 20px; } }
-  /* line 288, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container,
   .view-stanford-magazine-articles.most-recent-article .most-recent-article-container,
   .view-stanford-magazine-topics.most-recent-article .most-recent-article-container {
@@ -3840,12 +3347,10 @@ p.infotext {
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
     @media (max-width: 979px) {
-      /* line 288, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container,
       .view-stanford-magazine-articles.most-recent-article .most-recent-article-container,
       .view-stanford-magazine-topics.most-recent-article .most-recent-article-container {
         display: block; } }
-    /* line 296, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container,
     .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container,
     .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container {
@@ -3853,30 +3358,25 @@ p.infotext {
       background: #FFFFFF;
       padding: 50px 30px 30px; }
       @media (max-width: 979px) {
-        /* line 296, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container,
         .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container,
         .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container {
           width: auto; } }
       @media (max-width: 480px) {
-        /* line 296, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container,
         .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container,
         .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container {
           padding-top: 15px; } }
-      /* line 307, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-topic-card-content-container,
       .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-topic-card-content-container,
       .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-topic-card-content-container {
         position: absolute;
         bottom: 40px; }
         @media (max-width: 979px) {
-          /* line 307, ../scss/components/_soe_dm_article.scss */
           .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-topic-card-content-container,
           .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-topic-card-content-container,
           .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-topic-card-content-container {
             position: static; } }
-      /* line 315, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-date,
       .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-date,
       .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-date {
@@ -3884,7 +3384,6 @@ p.infotext {
         font-size: 1em;
         font-weight: 100;
         margin-bottom: 10px; }
-      /* line 322, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title,
       .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title,
       .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title {
@@ -3892,12 +3391,10 @@ p.infotext {
         line-height: 1.2em;
         font-weight: 600; }
         @media (max-width: 1199px) and (min-width: 979px) {
-          /* line 322, ../scss/components/_soe_dm_article.scss */
           .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title,
           .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title,
           .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title {
             font-size: 1em; } }
-        /* line 330, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a,
         .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a,
         .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a {
@@ -3906,7 +3403,6 @@ p.infotext {
           text-decoration: underline;
           -webkit-text-decoration-skip: ink;
           text-decoration-skip: ink; }
-          /* line 336, ../scss/components/_soe_dm_article.scss */
           .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:focus, .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:hover,
           .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:focus,
           .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:hover,
@@ -3914,70 +3410,58 @@ p.infotext {
           .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:hover {
             -webkit-text-decoration-color: #333333;
             text-decoration-color: #333333; }
-        /* line 342, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title.mag-article-color-orange a,
         .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title.mag-article-color-orange a,
         .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title.mag-article-color-orange a {
           -webkit-text-decoration-color: #FFBD54;
           text-decoration-color: #FFBD54; }
-        /* line 346, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title.mag-article-color-turquoise a,
         .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title.mag-article-color-turquoise a,
         .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title.mag-article-color-turquoise a {
           -webkit-text-decoration-color: #00ECE9;
           text-decoration-color: #00ECE9; }
-        /* line 350, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title.mag-article-color-pink a,
         .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title.mag-article-color-pink a,
         .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-title.mag-article-color-pink a {
           -webkit-text-decoration-color: #FF525C;
           text-decoration-color: #FF525C; }
-      /* line 355, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-topics,
       .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-topics,
       .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-topics {
         font-size: 0.9em;
         line-height: 1.3em;
         margin: 30px 0; }
-      /* line 361, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue,
       .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue,
       .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue {
         position: absolute;
         bottom: 15px;
         right: 15px; }
-        /* line 366, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue[class*="mag-issue-color-"],
         .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue[class*="mag-issue-color-"],
         .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue[class*="mag-issue-color-"] {
           padding: 0 9px;
           font-size: 0.9em; }
-        /* line 371, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue.mag-issue-color-orange,
         .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue.mag-issue-color-orange,
         .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue.mag-issue-color-orange {
           background: #FFBD54; }
-        /* line 375, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue.mag-issue-color-turquoise,
         .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue.mag-issue-color-turquoise,
         .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue.mag-issue-color-turquoise {
           background: #00ECE9; }
-        /* line 379, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue.mag-issue-color-pink,
         .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue.mag-issue-color-pink,
         .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue.mag-issue-color-pink {
           background: #FF525C; }
-        /* line 383, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue a,
         .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue a,
         .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-topic-card-container .mag-article-issue a {
           color: #333333; }
-    /* line 389, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-article-img,
     .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-article-img,
     .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-article-img {
       overflow: hidden; }
-      /* line 392, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-article-img:hover img,
       .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-article-img:hover img,
       .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-article-img:hover img {
@@ -3985,7 +3469,6 @@ p.infotext {
         -moz-transform: scale(1.03);
         -o-transform: scale(1.03);
         transform: scale(1.03); }
-      /* line 396, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-article-img img,
       .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-article-img img,
       .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-article-img img {
@@ -3994,40 +3477,37 @@ p.infotext {
         -o-transition: all 1s ease;
         transition: all 1s ease; }
         @media (max-width: 979px) {
-          /* line 396, ../scss/components/_soe_dm_article.scss */
           .view-stanford-magazine-article-most-recent.most-recent-article .most-recent-article-container .mag-article-img img,
           .view-stanford-magazine-articles.most-recent-article .most-recent-article-container .mag-article-img img,
           .view-stanford-magazine-topics.most-recent-article .most-recent-article-container .mag-article-img img {
             width: 100%; } }
-/* line 407, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-most-recent.article-grouping .views-row,
 .view-stanford-magazine-articles.article-grouping .views-row,
 .view-stanford-magazine-topics.article-grouping .views-row {
   margin-bottom: 80px; }
   @media (max-width: 480px) {
-    /* line 407, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .views-row,
     .view-stanford-magazine-articles.article-grouping .views-row,
     .view-stanford-magazine-topics.article-grouping .views-row {
       margin-bottom: 20px; } }
-/* line 414, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-most-recent.article-grouping.views-grid-three .views-row,
 .view-stanford-magazine-articles.article-grouping.views-grid-three .views-row,
 .view-stanford-magazine-topics.article-grouping.views-grid-three .views-row {
   margin-right: 2%;
   width: 31%; }
   @media (max-width: 581px) {
-    /* line 414, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping.views-grid-three .views-row,
     .view-stanford-magazine-articles.article-grouping.views-grid-three .views-row,
     .view-stanford-magazine-topics.article-grouping.views-grid-three .views-row {
       width: 100%; } }
-/* line 422, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-most-recent.article-grouping.views-grid-three .views-row.views-row-3,
 .view-stanford-magazine-articles.article-grouping.views-grid-three .views-row.views-row-3,
 .view-stanford-magazine-topics.article-grouping.views-grid-three .views-row.views-row-3 {
   margin-right: 0; }
-/* line 426, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container,
 .view-stanford-magazine-articles.article-grouping .mag-topic-card-container,
 .view-stanford-magazine-topics.article-grouping .mag-topic-card-container {
@@ -4037,21 +3517,18 @@ p.infotext {
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 432, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-date,
   .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-date,
   .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-date {
     color: #606060;
     font-size: 0.9em;
     font-weight: 100; }
-  /* line 438, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title,
   .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title,
   .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title {
     font-size: 1.3em;
     line-height: 1.3em;
     font-weight: 600; }
-    /* line 443, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a {
@@ -4060,7 +3537,6 @@ p.infotext {
       text-decoration: underline;
       -webkit-text-decoration-skip: ink;
       text-decoration-skip: ink; }
-      /* line 449, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:focus, .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:hover,
       .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:focus,
       .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:hover,
@@ -4068,70 +3544,59 @@ p.infotext {
       .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title[class*="mag-article-color-"] a:hover {
         -webkit-text-decoration-color: #333333;
         text-decoration-color: #333333; }
-    /* line 455, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-orange a,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-orange a,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-orange a {
       -webkit-text-decoration-color: #FFBD54;
       text-decoration-color: #FFBD54; }
-    /* line 459, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-turquoise a,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-turquoise a,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-turquoise a {
       -webkit-text-decoration-color: #00ECE9;
       text-decoration-color: #00ECE9; }
-    /* line 463, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-pink a,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-pink a,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-title.mag-article-color-pink a {
       -webkit-text-decoration-color: #FF525C;
       text-decoration-color: #FF525C; }
-  /* line 468, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-topics,
   .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-topics,
   .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-topics {
     font-size: 0.8em;
     line-height: 1.2em;
     margin: 30px 0; }
-  /* line 474, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue,
   .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue,
   .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue {
     position: absolute;
     bottom: 15px;
     right: 15px; }
-    /* line 479, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue[class*="mag-issue-color-"],
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue[class*="mag-issue-color-"],
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue[class*="mag-issue-color-"] {
       padding: 0 9px;
       font-size: 0.8em; }
-    /* line 484, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-orange,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-orange,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-orange {
       background: #FFBD54; }
-    /* line 488, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-turquoise,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-turquoise,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-turquoise {
       background: #00ECE9; }
-    /* line 492, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-pink,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-pink,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue.mag-issue-color-pink {
       background: #FF525C; }
-    /* line 496, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-most-recent.article-grouping .mag-topic-card-container .mag-article-issue a,
     .view-stanford-magazine-articles.article-grouping .mag-topic-card-container .mag-article-issue a,
     .view-stanford-magazine-topics.article-grouping .mag-topic-card-container .mag-article-issue a {
       color: #333333; }
-/* line 502, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-most-recent.article-grouping .mag-article-img,
 .view-stanford-magazine-articles.article-grouping .mag-article-img,
 .view-stanford-magazine-topics.article-grouping .mag-article-img {
   overflow: hidden; }
-  /* line 505, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-most-recent.article-grouping .mag-article-img:hover img,
   .view-stanford-magazine-articles.article-grouping .mag-article-img:hover img,
   .view-stanford-magazine-topics.article-grouping .mag-article-img:hover img {
@@ -4139,7 +3604,6 @@ p.infotext {
     -moz-transform: scale(1.03);
     -o-transform: scale(1.03);
     transform: scale(1.03); }
-  /* line 509, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-most-recent.article-grouping .mag-article-img img,
   .view-stanford-magazine-articles.article-grouping .mag-article-img img,
   .view-stanford-magazine-topics.article-grouping .mag-article-img img {
@@ -4148,16 +3612,14 @@ p.infotext {
     -o-transition: all 1s ease;
     transition: all 1s ease; }
 
-/* line 516, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-topics.most-recent-article {
   margin-top: -30px; }
 
-/* line 526, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-mag-landing-page.views-grid-three .views-row,
 .view-stanford-magazine-collection-mag-landing-page.views-grid-three .views-row,
 .view-display-id-article_collection_bottom_block.views-grid-three .views-row {
   margin-bottom: 0; }
-/* line 530, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-mag-landing-page h2,
 .view-stanford-magazine-collection-mag-landing-page h2,
 .view-display-id-article_collection_bottom_block h2 {
@@ -4169,18 +3631,16 @@ p.infotext {
   margin: 0 auto 60px;
   text-align: center; }
   @media (min-width: 1200px) {
-    /* line 530, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page h2,
     .view-stanford-magazine-collection-mag-landing-page h2,
     .view-display-id-article_collection_bottom_block h2 {
       width: 40%; } }
   @media (max-width: 767px) {
-    /* line 530, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page h2,
     .view-stanford-magazine-collection-mag-landing-page h2,
     .view-display-id-article_collection_bottom_block h2 {
       width: 100%; } }
-/* line 549, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(1), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(1),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(1),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(1),
@@ -4189,7 +3649,6 @@ p.infotext {
   width: 22.5%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 549, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(1), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(1),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(1),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(1),
@@ -4197,7 +3656,7 @@ p.infotext {
     .view-display-id-article_collection_bottom_block.view-display-id-page_1_3 .views-row:nth-child(1) {
       width: 100%;
       margin-right: 0; } }
-/* line 558, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2),
@@ -4206,7 +3665,6 @@ p.infotext {
   width: 45%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 558, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2),
@@ -4214,7 +3672,6 @@ p.infotext {
     .view-display-id-article_collection_bottom_block.view-display-id-page_1_3 .views-row:nth-child(2) {
       width: 100%;
       margin-right: 0; } }
-  /* line 567, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container,
   .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container,
   .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container,
@@ -4226,14 +3683,12 @@ p.infotext {
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
     @media (max-width: 979px) {
-      /* line 567, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container,
       .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container,
       .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container,
       .view-display-id-article_collection_bottom_block.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container,
       .view-display-id-article_collection_bottom_block.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container {
         padding: 15px 30px 30px; } }
-    /* line 575, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date,
@@ -4244,14 +3699,12 @@ p.infotext {
       font-weight: 100;
       margin-bottom: 10px; }
       @media (max-width: 979px) {
-        /* line 575, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date,
         .view-display-id-article_collection_bottom_block.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date,
         .view-display-id-article_collection_bottom_block.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-date {
           font-size: 0.9em; } }
-    /* line 585, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title,
@@ -4261,7 +3714,6 @@ p.infotext {
       line-height: 1.2em;
       font-weight: 600; }
       @media (max-width: 979px) {
-        /* line 585, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title,
@@ -4269,7 +3721,6 @@ p.infotext {
         .view-display-id-article_collection_bottom_block.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-title {
           font-size: 1.3em;
           line-height: 1.3em; } }
-    /* line 595, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics,
@@ -4279,7 +3730,6 @@ p.infotext {
       line-height: 1.3em;
       margin: 30px 0; }
       @media (max-width: 979px) {
-        /* line 595, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics, .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics,
@@ -4287,7 +3737,7 @@ p.infotext {
         .view-display-id-article_collection_bottom_block.view-display-id-page_1_3 .views-row:nth-child(2) .mag-article-container .mag-article-content-container .mag-article-topics {
           font-size: 0.8em;
           line-height: 1.2em; } }
-/* line 608, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(3), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(3),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(3),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(3),
@@ -4296,14 +3746,13 @@ p.infotext {
   width: 22.5%;
   margin-right: 0; }
   @media (max-width: 979px) {
-    /* line 608, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(3), .view-stanford-magazine-article-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(3),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_10_12 .views-row:nth-child(3),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-page_1_3 .views-row:nth-child(3),
     .view-display-id-article_collection_bottom_block.view-display-id-block_10_12 .views-row:nth-child(3),
     .view-display-id-article_collection_bottom_block.view-display-id-page_1_3 .views-row:nth-child(3) {
       width: 100%; } }
-/* line 621, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1),
@@ -4312,7 +3761,6 @@ p.infotext {
   width: 45%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 621, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1),
@@ -4320,7 +3768,6 @@ p.infotext {
     .view-display-id-article_collection_bottom_block.view-display-id-block_4_6 .views-row:nth-child(1) {
       width: 100%;
       margin-right: 0; } }
-  /* line 630, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container,
   .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container,
   .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container,
@@ -4332,14 +3779,12 @@ p.infotext {
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
     @media (max-width: 979px) {
-      /* line 630, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container,
       .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container,
       .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container,
       .view-display-id-article_collection_bottom_block.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container,
       .view-display-id-article_collection_bottom_block.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container {
         padding: 15px 30px 30px; } }
-    /* line 638, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date,
@@ -4350,14 +3795,12 @@ p.infotext {
       font-weight: 100;
       margin-bottom: 10px; }
       @media (max-width: 979px) {
-        /* line 638, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date,
         .view-display-id-article_collection_bottom_block.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date,
         .view-display-id-article_collection_bottom_block.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-date {
           font-size: 0.9em; } }
-    /* line 648, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title,
@@ -4367,7 +3810,6 @@ p.infotext {
       line-height: 1.2em;
       font-weight: 600; }
       @media (max-width: 979px) {
-        /* line 648, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title,
@@ -4375,7 +3817,6 @@ p.infotext {
         .view-display-id-article_collection_bottom_block.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-title {
           font-size: 1.3em;
           line-height: 1.3em; } }
-    /* line 658, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics,
@@ -4385,7 +3826,6 @@ p.infotext {
       line-height: 1.3em;
       margin: 30px 0; }
       @media (max-width: 979px) {
-        /* line 658, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics, .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics,
@@ -4393,7 +3833,7 @@ p.infotext {
         .view-display-id-article_collection_bottom_block.view-display-id-block_4_6 .views-row:nth-child(1) .mag-article-container .mag-article-content-container .mag-article-topics {
           font-size: 0.8em;
           line-height: 1.2em; } }
-/* line 671, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(2), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(2),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(2),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(2),
@@ -4402,7 +3842,6 @@ p.infotext {
   width: 22.5%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 671, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(2), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(2),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(2),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(2),
@@ -4410,7 +3849,7 @@ p.infotext {
     .view-display-id-article_collection_bottom_block.view-display-id-block_4_6 .views-row:nth-child(2) {
       width: 100%;
       margin-right: 0; } }
-/* line 680, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(3), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(3),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(3),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(3),
@@ -4419,52 +3858,47 @@ p.infotext {
   width: 22.5%;
   margin-right: 0; }
   @media (max-width: 979px) {
-    /* line 680, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(3), .view-stanford-magazine-article-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(3),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_13_15 .views-row:nth-child(3),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_4_6 .views-row:nth-child(3),
     .view-display-id-article_collection_bottom_block.view-display-id-block_13_15 .views-row:nth-child(3),
     .view-display-id-article_collection_bottom_block.view-display-id-block_4_6 .views-row:nth-child(3) {
       width: 100%; } }
-/* line 692, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(1),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(1),
 .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(1) {
   width: 22.5%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 692, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(1),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(1),
     .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(1) {
       width: 100%;
       margin-right: 0; } }
-/* line 701, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(2),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(2),
 .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(2) {
   width: 22.5%;
   margin-right: 4.5%; }
   @media (max-width: 979px) {
-    /* line 701, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(2),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(2),
     .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(2) {
       width: 100%;
       margin-right: 0; } }
-/* line 710, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3),
 .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3),
 .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(3) {
   width: 45%;
   margin-right: 0; }
   @media (max-width: 979px) {
-    /* line 710, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3),
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3),
     .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(3) {
       width: 100%; } }
-  /* line 718, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container,
   .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container,
   .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container {
@@ -4474,12 +3908,10 @@ p.infotext {
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
     @media (max-width: 979px) {
-      /* line 718, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container,
       .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container,
       .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container {
         padding: 15px 30px 30px; } }
-    /* line 726, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-date,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-date,
     .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-date {
@@ -4488,12 +3920,10 @@ p.infotext {
       font-weight: 100;
       margin-bottom: 10px; }
       @media (max-width: 979px) {
-        /* line 726, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-date,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-date,
         .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-date {
           font-size: 0.9em; } }
-    /* line 736, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-title,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-title,
     .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-title {
@@ -4501,13 +3931,11 @@ p.infotext {
       line-height: 1.2em;
       font-weight: 600; }
       @media (max-width: 979px) {
-        /* line 736, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-title,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-title,
         .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-title {
           font-size: 1.3em;
           line-height: 1.3em; } }
-    /* line 746, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-topics,
     .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-topics,
     .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-topics {
@@ -4515,29 +3943,25 @@ p.infotext {
       line-height: 1.3em;
       margin: 30px 0; }
       @media (max-width: 979px) {
-        /* line 746, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-topics,
         .view-stanford-magazine-collection-mag-landing-page.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-topics,
         .view-display-id-article_collection_bottom_block.view-display-id-block_7_9 .views-row:nth-child(3) .mag-article-container .mag-article-content-container .mag-article-topics {
           font-size: 0.8em;
           line-height: 1.2em; } }
-/* line 761, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-mag-landing-page .mag-article-container,
 .view-stanford-magazine-collection-mag-landing-page .mag-article-container,
 .view-display-id-article_collection_bottom_block .mag-article-container {
   margin-bottom: 80px; }
   @media (max-width: 979px) {
-    /* line 761, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container,
     .view-stanford-magazine-collection-mag-landing-page .mag-article-container,
     .view-display-id-article_collection_bottom_block .mag-article-container {
       margin-bottom: 40px; } }
-  /* line 767, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-img,
   .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-img,
   .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-img {
     overflow: hidden; }
-    /* line 770, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-img:hover img,
     .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-img:hover img,
     .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-img:hover img {
@@ -4545,7 +3969,6 @@ p.infotext {
       -moz-transform: scale(1.03);
       -o-transform: scale(1.03);
       transform: scale(1.03); }
-    /* line 774, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-img img,
     .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-img img,
     .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-img img {
@@ -4554,12 +3977,10 @@ p.infotext {
       -o-transition: all 1s ease;
       transition: all 1s ease; }
       @media (max-width: 979px) {
-        /* line 774, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-img img,
         .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-img img,
         .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-img img {
           width: 100%; } }
-  /* line 782, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container,
   .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container,
   .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container {
@@ -4569,20 +3990,17 @@ p.infotext {
     -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-    /* line 788, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-date,
     .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-date,
     .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-date {
       color: #606060;
       font-size: 0.9em;
       font-weight: 100; }
-    /* line 794, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title,
     .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title,
     .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-title {
       font-size: 1.3em;
       line-height: 1.3em; }
-      /* line 798, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a,
       .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a,
       .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a {
@@ -4591,7 +4009,6 @@ p.infotext {
         text-decoration: underline;
         -webkit-text-decoration-skip: ink;
         text-decoration-skip: ink; }
-        /* line 804, ../scss/components/_soe_dm_article.scss */
         .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a:focus, .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a:hover,
         .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a:focus,
         .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a:hover,
@@ -4599,137 +4016,116 @@ p.infotext {
         .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a:hover {
           -webkit-text-decoration-color: #333333;
           text-decoration-color: #333333; }
-      /* line 810, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-orange a,
       .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-orange a,
       .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-orange a {
         -webkit-text-decoration-color: #FFBD54;
         text-decoration-color: #FFBD54; }
-      /* line 814, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-turquoise a,
       .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-turquoise a,
       .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-turquoise a {
         -webkit-text-decoration-color: #00ECE9;
         text-decoration-color: #00ECE9; }
-      /* line 818, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-pink a,
       .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-pink a,
       .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-pink a {
         -webkit-text-decoration-color: #FF525C;
         text-decoration-color: #FF525C; }
-    /* line 823, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-topics,
     .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-topics,
     .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-topics {
       font-size: 0.8em;
       line-height: 1.2em;
       margin: 30px 0; }
-    /* line 829, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue,
     .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue,
     .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-issue {
       position: absolute;
       bottom: 15px;
       right: 15px; }
-      /* line 834, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue[class*="mag-issue-color-"],
       .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue[class*="mag-issue-color-"],
       .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-issue[class*="mag-issue-color-"] {
         padding: 0 9px;
         font-size: 0.9em; }
-      /* line 839, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-orange,
       .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-orange,
       .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-orange {
         background: #FFBD54; }
-      /* line 843, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-turquoise,
       .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-turquoise,
       .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-turquoise {
         background: #00ECE9; }
-      /* line 847, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-pink,
       .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-pink,
       .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-issue.mag-issue-color-pink {
         background: #FF525C; }
-      /* line 851, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue a,
       .view-stanford-magazine-collection-mag-landing-page .mag-article-container .mag-article-content-container .mag-article-issue a,
       .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-issue a {
         color: #333333; }
 
-/* line 863, ../scss/components/_soe_dm_article.scss */
 .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-title a {
   font-weight: 600; }
 
-/* line 872, ../scss/components/_soe_dm_article.scss */
 .page-magazine .main {
   padding-bottom: 0; }
   @media (min-width: 979px) {
-    /* line 872, ../scss/components/_soe_dm_article.scss */
     .page-magazine .main {
       padding-top: 100px; } }
   @media (max-width: 767px) {
-    /* line 878, ../scss/components/_soe_dm_article.scss */
     .page-magazine .main .container {
       margin-bottom: 0; } }
-  /* line 883, ../scss/components/_soe_dm_article.scss */
   .page-magazine .main .container .content-head {
     margin-bottom: 0; }
-/* line 889, ../scss/components/_soe_dm_article.scss */
+
 .page-magazine #page-title {
   text-align: center; }
-/* line 894, ../scss/components/_soe_dm_article.scss */
+
 .page-magazine .mailchimp-magazine-block #mc_embed_signup_scroll {
   box-shadow: none;
   -webkit-box-shadow: none;
   margin-bottom: 0; }
   @media (max-width: 767px) {
-    /* line 894, ../scss/components/_soe_dm_article.scss */
     .page-magazine .mailchimp-magazine-block #mc_embed_signup_scroll {
       padding: 40px 0; } }
-/* line 906, ../scss/components/_soe_dm_article.scss */
+
 .page-magazine form#mc-embedded-subscribe-form {
   margin-bottom: 0; }
-/* line 912, ../scss/components/_soe_dm_article.scss */
+
 .page-magazine .block-stanford-soe-helper-magazine a.btn {
   margin: 0 0 80px; }
-/* line 917, ../scss/components/_soe_dm_article.scss */
+
 .page-magazine #content-body-bottom {
   margin-top: 5%; }
 
-/* line 925, ../scss/components/_soe_dm_article.scss */
 .page-magazine-all .mailchimp-magazine-block #mc_embed_signup_scroll,
 .page-taxonomy-term .mailchimp-magazine-block #mc_embed_signup_scroll {
   box-shadow: none;
   -webkit-box-shadow: none;
   margin-bottom: 0; }
   @media (max-width: 767px) {
-    /* line 925, ../scss/components/_soe_dm_article.scss */
     .page-magazine-all .mailchimp-magazine-block #mc_embed_signup_scroll,
     .page-taxonomy-term .mailchimp-magazine-block #mc_embed_signup_scroll {
       padding: 40px 0; } }
-/* line 937, ../scss/components/_soe_dm_article.scss */
+
 .page-magazine-all form#mc-embedded-subscribe-form,
 .page-taxonomy-term form#mc-embedded-subscribe-form {
   margin-bottom: 0; }
-/* line 942, ../scss/components/_soe_dm_article.scss */
+
 .page-magazine-all #content-body-bottom,
 .page-taxonomy-term #content-body-bottom {
   margin-top: 5%; }
 
-/* line 952, ../scss/components/_soe_dm_article.scss */
 .view-stanford-magazine-article-department .mag-article-container .mag-article-img,
 .view-stanford-magazine-article-featured .mag-article-container .mag-article-img {
   overflow: hidden; }
-  /* line 955, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-department .mag-article-container .mag-article-img:hover img,
   .view-stanford-magazine-article-featured .mag-article-container .mag-article-img:hover img {
     -webkit-transform: scale(1.03);
     -moz-transform: scale(1.03);
     -o-transform: scale(1.03);
     transform: scale(1.03); }
-  /* line 959, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-department .mag-article-container .mag-article-img img,
   .view-stanford-magazine-article-featured .mag-article-container .mag-article-img img {
     -webkit-transition: all 1s ease;
@@ -4737,7 +4133,7 @@ p.infotext {
     -o-transition: all 1s ease;
     transition: all 1s ease;
     width: 100%; }
-/* line 965, ../scss/components/_soe_dm_article.scss */
+
 .view-stanford-magazine-article-department .mag-article-container .mag-article-content-container,
 .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container {
   background: #FFFFFF;
@@ -4746,11 +4142,9 @@ p.infotext {
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
   @media (max-width: 979px) {
-    /* line 965, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-department .mag-article-container .mag-article-content-container,
     .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container {
       padding: 15px 30px 30px; } }
-  /* line 973, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-department .mag-article-container .mag-article-content-container .mag-article-date,
   .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-date {
     color: #606060;
@@ -4758,39 +4152,32 @@ p.infotext {
     font-weight: 100;
     margin-bottom: 10px; }
     @media (max-width: 979px) {
-      /* line 973, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-department .mag-article-container .mag-article-content-container .mag-article-date,
       .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-date {
         font-size: 0.9em; } }
-  /* line 984, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-department .mag-article-container .mag-article-content-container .mag-article-title h2,
   .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-title h2 {
     font-size: 1.4em; }
-    /* line 987, ../scss/components/_soe_dm_article.scss */
     .view-stanford-magazine-article-department .mag-article-container .mag-article-content-container .mag-article-title h2 a,
     .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-title h2 a {
       -webkit-text-decoration-color: #00ECE9;
       text-decoration-color: #00ECE9; }
-      /* line 990, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-department .mag-article-container .mag-article-content-container .mag-article-title h2 a:focus, .view-stanford-magazine-article-department .mag-article-container .mag-article-content-container .mag-article-title h2 a:hover,
       .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-title h2 a:focus,
       .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-title h2 a:hover {
         -webkit-text-decoration-color: #333333;
         text-decoration-color: #333333; }
-  /* line 998, ../scss/components/_soe_dm_article.scss */
   .view-stanford-magazine-article-department .mag-article-container .mag-article-content-container .mag-article-topics,
   .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-topics {
     font-size: 0.9em;
     line-height: 1.3em;
     margin: 30px 0; }
     @media (max-width: 979px) {
-      /* line 998, ../scss/components/_soe_dm_article.scss */
       .view-stanford-magazine-article-department .mag-article-container .mag-article-content-container .mag-article-topics,
       .view-stanford-magazine-article-featured .mag-article-container .mag-article-content-container .mag-article-topics {
         font-size: 0.8em;
         line-height: 1.2em; } }
 
-/* line 1014, ../scss/components/_soe_dm_article.scss */
 .node-type-stanford-magazine-article .paragraphs-item-p-two-columns {
   font-family: "Roboto Slab", serif;
   font-size: 1.4em;
@@ -4798,76 +4185,64 @@ p.infotext {
   column-count: 1;
   column-gap: 0;
   width: 85%; }
+
 @media (max-width: 480px) {
-  /* line 1023, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article h1 {
     width: 100%; } }
-/* line 1030, ../scss/components/_soe_dm_article.scss */
+
 .node-type-stanford-magazine-article .paragraphs-item-p-wysiwyg-simple a {
   text-decoration: underline; }
+
 @media (max-width: 979px) {
-  /* line 1029, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .paragraphs-item-p-wysiwyg-simple {
     width: 85%; } }
+
 @media (max-width: 480px) {
-  /* line 1029, ../scss/components/_soe_dm_article.scss */
   .node-type-stanford-magazine-article .paragraphs-item-p-wysiwyg-simple {
     width: 100%; } }
 
-/* line 1043, ../scss/components/_soe_dm_article.scss */
 .entity-paragraphs-item iframe {
   width: 100%; }
-  /* line 1045, ../scss/components/_soe_dm_article.scss */
   .entity-paragraphs-item iframe.iframe-auto {
     height: auto; }
-/* line 1050, ../scss/components/_soe_dm_article.scss */
+
 .entity-paragraphs-item iframe[src*="youtube"],
 .entity-paragraphs-item iframe[src*="vimeo"] {
   height: 400px; }
 
-/* line 1059, ../scss/components/_soe_dm_article.scss */
 #block-ds-extras-related-departments {
   width: 85%;
   border-top: 1px solid #CCCCCC;
   margin: 0 auto 80px;
   padding-top: 20px; }
   @media (max-width: 480px) {
-    /* line 1059, ../scss/components/_soe_dm_article.scss */
     #block-ds-extras-related-departments {
       width: 100%; } }
-  /* line 1068, ../scss/components/_soe_dm_article.scss */
   #block-ds-extras-related-departments h2 {
     font-size: 0.9em;
     font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
     margin-bottom: 0; }
-  /* line 1074, ../scss/components/_soe_dm_article.scss */
   #block-ds-extras-related-departments .field-name-field-s-mag-article-dept {
     font-size: 0.9em;
     line-height: 1.3em;
     width: 45%; }
     @media (max-width: 480px) {
-      /* line 1074, ../scss/components/_soe_dm_article.scss */
       #block-ds-extras-related-departments .field-name-field-s-mag-article-dept {
         width: 100%; } }
 
-/* line 12, ../scss/components/_soe_dm_issue.scss */
 .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container {
   position: relative; }
-  /* line 15, ../scss/components/_soe_dm_issue.scss */
   .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container img {
     object-fit: cover;
     object-position: center center;
     width: 100%;
     height: calc(100vh - 144px); }
     @media (max-width: 1200px) {
-      /* line 15, ../scss/components/_soe_dm_issue.scss */
       .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container img {
         height: calc(100vh - 189px); } }
     @media (max-width: 979px) {
-      /* line 15, ../scss/components/_soe_dm_issue.scss */
       .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container img {
         height: auto; } }
-  /* line 28, ../scss/components/_soe_dm_issue.scss */
   .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container .mag-feat-content-container {
     color: #FFFFFF;
     position: absolute;
@@ -4876,11 +4251,9 @@ p.infotext {
     width: 100%;
     z-index: 1; }
     @media (max-width: 767px) {
-      /* line 28, ../scss/components/_soe_dm_issue.scss */
       .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container .mag-feat-content-container {
         color: #333333;
         position: static; } }
-    /* line 40, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container .mag-feat-content-container h1 {
       color: #FFFFFF;
       font-size: 1.6em;
@@ -4889,34 +4262,26 @@ p.infotext {
       padding: 15px 25px;
       background: rgba(0, 0, 0, 0.3); }
       @media (max-width: 767px) {
-        /* line 40, ../scss/components/_soe_dm_issue.scss */
         .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container .mag-feat-content-container h1 {
           display: block;
           background: rgba(0, 0, 0, 0.7);
           margin-top: 0; } }
-      /* line 53, ../scss/components/_soe_dm_issue.scss */
       .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-orange {
         border-color: #FFBD54; }
-      /* line 57, ../scss/components/_soe_dm_issue.scss */
       .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-turquoise {
         border-color: #00ECE9; }
-      /* line 61, ../scss/components/_soe_dm_issue.scss */
       .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-pink {
         border-color: #FF525C; }
-    /* line 66, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container .mag-feat-content-container p {
       margin: 40px 0 80px; }
-    /* line 70, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container .mag-feat-content-container:after {
       content: url("../img/soe_chevron_down_white.png");
       position: absolute;
       bottom: 50px; }
       @media (max-width: 767px) {
-        /* line 70, ../scss/components/_soe_dm_issue.scss */
         .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container .mag-feat-content-container:after {
           content: url("../img/soe_chevron_down_black.png");
           bottom: -25px; } }
-  /* line 81, ../scss/components/_soe_dm_issue.scss */
   .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container:after {
     content: '';
     position: absolute;
@@ -4930,68 +4295,55 @@ p.infotext {
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=  '#00000000', endColorstr='#BF000000', GradientType=0); }
     @media (max-width: 767px) {
-      /* line 81, ../scss/components/_soe_dm_issue.scss */
       .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container:after {
         background: none; } }
-/* line 94, ../scss/components/_soe_dm_issue.scss */
+
 .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container {
   width: 1000px;
   margin: 0 auto; }
   @media (max-width: 1200px) {
-    /* line 94, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container {
       width: 800px; } }
   @media (max-width: 979px) {
-    /* line 94, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container {
       width: 650px; } }
   @media (max-width: 767px) {
-    /* line 94, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container {
       width: auto;
       margin: 0 20px; } }
-  /* line 108, ../scss/components/_soe_dm_issue.scss */
   .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container .mag-feat-date {
     color: #606060;
     font-size: 1em;
     font-weight: 100;
     margin: 40px 0 20px; }
-  /* line 115, ../scss/components/_soe_dm_issue.scss */
   .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container a h2.mag-feat-title {
     font-size: 2.8em;
     letter-spacing: 0;
     margin-bottom: 10px; }
-    /* line 120, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container a h2.mag-feat-title[class*="mag-article-color-"] {
       color: #333333;
       text-decoration: underline;
       -webkit-text-decoration-skip: ink;
       text-decoration-skip: ink; }
-      /* line 125, ../scss/components/_soe_dm_issue.scss */
       .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container a h2.mag-feat-title[class*="mag-article-color-"]:focus, .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container a h2.mag-feat-title[class*="mag-article-color-"]:hover {
         -webkit-text-decoration-color: #333333;
         text-decoration-color: #333333; }
-    /* line 131, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container a h2.mag-feat-title.mag-article-color-orange {
       -webkit-text-decoration-color: #FFBD54;
       text-decoration-color: #FFBD54; }
-    /* line 135, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container a h2.mag-feat-title.mag-article-color-turquoise {
       -webkit-text-decoration-color: #00ECE9;
       text-decoration-color: #00ECE9; }
-    /* line 139, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container a h2.mag-feat-title.mag-article-color-pink {
       -webkit-text-decoration-color: #FF525C;
       text-decoration-color: #FF525C; }
-  /* line 144, ../scss/components/_soe_dm_issue.scss */
   .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container .mag-feat-dek {
     font-size: 1.3em;
     width: 85%;
     margin-bottom: 40px; }
-  /* line 150, ../scss/components/_soe_dm_issue.scss */
   .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-details-container .mag-feat-tax {
     font-size: 1em; }
-/* line 156, ../scss/components/_soe_dm_issue.scss */
+
 .node-type-stanford-magazine-issue .mag-article-container {
   position: relative;
   background: #FFFFFF;
@@ -4999,180 +4351,146 @@ p.infotext {
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 162, ../scss/components/_soe_dm_issue.scss */
   .node-type-stanford-magazine-issue .mag-article-container .mag-article-date {
     color: #606060;
     font-size: 0.9em;
     font-weight: 100;
     margin-bottom: 5px; }
-  /* line 170, ../scss/components/_soe_dm_issue.scss */
   .node-type-stanford-magazine-issue .mag-article-container a h2.mag-article-title {
     font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 1.6em;
     line-height: 1.2em; }
-    /* line 175, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .mag-article-container a h2.mag-article-title[class*="mag-article-color-"] {
       color: #333333;
       text-decoration: underline;
       -webkit-text-decoration-skip: ink;
       text-decoration-skip: ink; }
-      /* line 180, ../scss/components/_soe_dm_issue.scss */
       .node-type-stanford-magazine-issue .mag-article-container a h2.mag-article-title[class*="mag-article-color-"]:focus, .node-type-stanford-magazine-issue .mag-article-container a h2.mag-article-title[class*="mag-article-color-"]:hover {
         -webkit-text-decoration-color: #333333;
         text-decoration-color: #333333; }
-    /* line 186, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .mag-article-container a h2.mag-article-title.mag-article-color-orange {
       -webkit-text-decoration-color: #FFBD54;
       text-decoration-color: #FFBD54; }
-    /* line 190, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .mag-article-container a h2.mag-article-title.mag-article-color-turquoise {
       -webkit-text-decoration-color: #00ECE9;
       text-decoration-color: #00ECE9; }
-    /* line 194, ../scss/components/_soe_dm_issue.scss */
     .node-type-stanford-magazine-issue .mag-article-container a h2.mag-article-title.mag-article-color-pink {
       -webkit-text-decoration-color: #FF525C;
       text-decoration-color: #FF525C; }
-  /* line 199, ../scss/components/_soe_dm_issue.scss */
   .node-type-stanford-magazine-issue .mag-article-container .mag-article-tax {
     font-size: 0.8em;
     line-height: 1.2em;
     margin: 30px 0; }
 
-/* line 210, ../scss/components/_soe_dm_issue.scss */
 .view-stanford-magazine-issues h1 {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: #606060;
   font-size: 1.3em;
   text-align: center;
   margin-bottom: 0; }
-/* line 218, ../scss/components/_soe_dm_issue.scss */
+
 .view-stanford-magazine-issues .views-row {
   margin-bottom: 100px; }
   @media (max-width: 979px) {
-    /* line 218, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .views-row {
       margin-bottom: 50px; } }
-  /* line 225, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .views-row:nth-child(3n+1) .mag-issue-col-1 {
     float: right;
     width: 22.5%; }
     @media (max-width: 979px) {
-      /* line 225, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .views-row:nth-child(3n+1) .mag-issue-col-1 {
         float: none;
         width: 100%; } }
-  /* line 234, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .views-row:nth-child(3n+1) .mag-issue-col-2 {
     float: left;
     width: 45%;
     margin-right: 5%; }
     @media (max-width: 979px) {
-      /* line 234, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .views-row:nth-child(3n+1) .mag-issue-col-2 {
         float: none;
         width: 100%;
         margin-right: 0; } }
-  /* line 245, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .views-row:nth-child(3n+1) .mag-issue-col-3 {
     float: right;
     width: 22.5%;
     margin-right: 5%; }
     @media (max-width: 979px) {
-      /* line 245, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .views-row:nth-child(3n+1) .mag-issue-col-3 {
         float: none;
         width: 100%;
         margin-right: 0; } }
-  /* line 258, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .views-row:nth-child(3n+2) .mag-issue-col-1 {
     float: left;
     width: 22.5%;
     margin-right: 5%; }
     @media (max-width: 979px) {
-      /* line 258, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .views-row:nth-child(3n+2) .mag-issue-col-1 {
         float: none;
         width: 100%;
         margin-right: 0; } }
-  /* line 269, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .views-row:nth-child(3n+2) .mag-issue-col-2 {
     float: left;
     width: 45%;
     margin-right: 5%; }
     @media (max-width: 979px) {
-      /* line 269, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .views-row:nth-child(3n+2) .mag-issue-col-2 {
         float: none;
         width: 100%;
         margin-right: 0; } }
-  /* line 280, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .views-row:nth-child(3n+2) .mag-issue-col-3 {
     float: left;
     width: 22.5%; }
     @media (max-width: 979px) {
-      /* line 280, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .views-row:nth-child(3n+2) .mag-issue-col-3 {
         float: none;
         width: 100%; } }
-  /* line 291, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .views-row:nth-child(3n+3) .mag-issue-col-1 {
     float: left;
     width: 22.5%; }
     @media (max-width: 979px) {
-      /* line 291, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .views-row:nth-child(3n+3) .mag-issue-col-1 {
         float: none;
         width: 100%; } }
-  /* line 300, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .views-row:nth-child(3n+3) .mag-issue-col-2 {
     float: right;
     width: 45%;
     margin-left: 5%; }
     @media (max-width: 979px) {
-      /* line 300, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .views-row:nth-child(3n+3) .mag-issue-col-2 {
         float: none;
         width: 100%;
         margin-left: 0; } }
-  /* line 311, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .views-row:nth-child(3n+3) .mag-issue-col-3 {
     float: left;
     width: 22.5%;
     margin-left: 5%; }
     @media (max-width: 979px) {
-      /* line 311, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .views-row:nth-child(3n+3) .mag-issue-col-3 {
         float: none;
         width: 100%;
         margin-left: 0; } }
-  /* line 323, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .views-row h2 {
     font-size: 2.8em;
     text-align: center;
     margin-bottom: 60px; }
-/* line 330, ../scss/components/_soe_dm_issue.scss */
+
 .view-stanford-magazine-issues .mag-feat-article-container {
   margin-bottom: 80px; }
   @media (max-width: 979px) {
-    /* line 330, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-feat-article-container {
       margin-bottom: 40px; } }
-  /* line 336, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .mag-feat-article-container .mag-article-img {
     overflow: hidden; }
-    /* line 339, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-feat-article-container .mag-article-img:hover img {
       -webkit-transform: scale(1.03);
       -moz-transform: scale(1.03);
       -o-transform: scale(1.03);
       transform: scale(1.03); }
-    /* line 343, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-feat-article-container .mag-article-img img {
       -webkit-transition: all 1s ease;
       -moz-transition: all 1s ease;
       -o-transition: all 1s ease;
       transition: all 1s ease; }
-  /* line 348, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container {
     background: #FFFFFF;
     padding: 50px 30px 30px;
@@ -5180,145 +4498,115 @@ p.infotext {
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
     @media (max-width: 979px) {
-      /* line 348, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container {
         padding: 15px 30px 30px; } }
-    /* line 356, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-date {
       color: #606060;
       font-size: 1em;
       font-weight: 100;
       margin-bottom: 10px; }
       @media (max-width: 979px) {
-        /* line 356, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-date {
           font-size: 0.9em; } }
-    /* line 366, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-title {
       font-size: 1.6em;
       line-height: 1.2em;
       font-weight: 600;
       margin-bottom: 12px; }
       @media (max-width: 979px) {
-        /* line 366, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-title {
           font-size: 1.3em;
           line-height: 1.3em; } }
-      /* line 376, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a {
         color: #333333;
         font-weight: 600;
         text-decoration: underline;
         -webkit-text-decoration-skip: ink;
         text-decoration-skip: ink; }
-        /* line 382, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a:focus, .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a:hover {
           -webkit-text-decoration-color: #333333;
           text-decoration-color: #333333; }
-      /* line 388, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-title.mag-article-color-orange a {
         -webkit-text-decoration-color: #FFBD54;
         text-decoration-color: #FFBD54; }
-      /* line 392, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-title.mag-article-color-turquoise a {
         -webkit-text-decoration-color: #00ECE9;
         text-decoration-color: #00ECE9; }
-      /* line 396, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-title.mag-article-color-pink a {
         -webkit-text-decoration-color: #FF525C;
         text-decoration-color: #FF525C; }
-    /* line 401, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-dek {
       line-height: 1.3em; }
-    /* line 405, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-topics {
       font-size: 0.9em;
       line-height: 1.3em;
       margin: 30px 0; }
       @media (max-width: 979px) {
-        /* line 405, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-issues .mag-feat-article-container .mag-article-content-container .mag-article-topics {
           font-size: 0.8em;
           line-height: 1.2em; } }
-/* line 417, ../scss/components/_soe_dm_issue.scss */
+
 .view-stanford-magazine-issues .mag-article-container {
   margin-bottom: 80px; }
   @media (max-width: 979px) {
-    /* line 417, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-article-container {
       margin-bottom: 40px; } }
-  /* line 423, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .mag-article-container .mag-article-img {
     overflow: hidden; }
-    /* line 426, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-article-container .mag-article-img:hover img {
       -webkit-transform: scale(1.03);
       -moz-transform: scale(1.03);
       -o-transform: scale(1.03);
       transform: scale(1.03); }
-    /* line 430, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-article-container .mag-article-img img {
       -webkit-transition: all 1s ease;
       -moz-transition: all 1s ease;
       -o-transition: all 1s ease;
       transition: all 1s ease; }
       @media (max-width: 979px) {
-        /* line 430, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-issues .mag-article-container .mag-article-img img {
           width: 100%; } }
-  /* line 438, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issues .mag-article-container .mag-article-content-container {
     background: #FFFFFF;
     padding: 15px 30px 30px;
     -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-    /* line 443, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-article-container .mag-article-content-container .mag-article-date {
       color: #606060;
       font-size: 0.9em;
       font-weight: 100; }
-    /* line 449, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-article-container .mag-article-content-container .mag-article-title {
       font-size: 1.3em;
       line-height: 1.3em;
       font-weight: 600; }
-      /* line 454, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a {
         color: #333333;
         font-weight: 600;
         text-decoration: underline;
         -webkit-text-decoration-skip: ink;
         text-decoration-skip: ink; }
-        /* line 460, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-issues .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a:focus, .view-stanford-magazine-issues .mag-article-container .mag-article-content-container .mag-article-title[class*="mag-article-color-"] a:hover {
           -webkit-text-decoration-color: #333333;
           text-decoration-color: #333333; }
-      /* line 466, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-orange a {
         -webkit-text-decoration-color: #FFBD54;
         text-decoration-color: #FFBD54; }
-      /* line 470, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-turquoise a {
         -webkit-text-decoration-color: #00ECE9;
         text-decoration-color: #00ECE9; }
-      /* line 474, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issues .mag-article-container .mag-article-content-container .mag-article-title.mag-article-color-pink a {
         -webkit-text-decoration-color: #FF525C;
         text-decoration-color: #FF525C; }
-    /* line 479, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issues .mag-article-container .mag-article-content-container .mag-article-topics {
       font-size: 0.8em;
       line-height: 1.2em;
       margin: 30px 0; }
 
-/* line 490, ../scss/components/_soe_dm_issue.scss */
 .view-stanford-magazine-article-issue- {
   text-align: center; }
-  /* line 493, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-article-issue- .mag-article-issue-container {
     position: relative; }
-    /* line 497, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-article-issue- .mag-article-issue-container .mag-article-issue-image-container:after {
       content: '';
       position: absolute;
@@ -5333,25 +4621,20 @@ p.infotext {
       background-repeat: repeat-x;
       filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=  '#00000000', endColorstr='#B3000000', GradientType=0); }
       @media (max-width: 1200px) {
-        /* line 497, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-article-issue- .mag-article-issue-container .mag-article-issue-image-container:after {
           left: 45px;
           right: 45px; } }
       @media (max-width: 979px) {
-        /* line 497, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-article-issue- .mag-article-issue-container .mag-article-issue-image-container:after {
           left: 0;
           right: 0; } }
-    /* line 517, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-article-issue- .mag-article-issue-container [class*="mag-issue-color-"] .mag-article-issue-content-container {
       position: absolute;
       bottom: 38%;
       width: 100%; }
       @media (max-width: 480px) {
-        /* line 517, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-article-issue- .mag-article-issue-container [class*="mag-issue-color-"] .mag-article-issue-content-container {
           position: relative; } }
-      /* line 525, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-article-issue- .mag-article-issue-container [class*="mag-issue-color-"] .mag-article-issue-content-container > a {
         font-family: "Roboto Slab", serif;
         color: #000000;
@@ -5360,17 +4643,13 @@ p.infotext {
         font-size: 1.6em;
         padding: 30px; }
         @media (max-width: 480px) {
-          /* line 525, ../scss/components/_soe_dm_issue.scss */
           .view-stanford-magazine-article-issue- .mag-article-issue-container [class*="mag-issue-color-"] .mag-article-issue-content-container > a {
             display: block; } }
-      /* line 538, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-article-issue- .mag-article-issue-container [class*="mag-issue-color-"] .mag-article-issue-content-container .mag-article-issue-title:after {
         content: "\00a0 \00a0 |\00a0 \00a0 "; }
         @media (max-width: 480px) {
-          /* line 538, ../scss/components/_soe_dm_issue.scss */
           .view-stanford-magazine-article-issue- .mag-article-issue-container [class*="mag-issue-color-"] .mag-article-issue-content-container .mag-article-issue-title:after {
             content: normal; } }
-      /* line 547, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-article-issue- .mag-article-issue-container [class*="mag-issue-color-"] .mag-article-issue-content-container .mag-article-issue-more:after {
         content: "";
         background-image: url("../img/soe_lg_arrow_right_black.svg");
@@ -5380,16 +4659,13 @@ p.infotext {
         padding-left: 41px;
         margin-left: 12px; }
         @media (max-width: 767px) {
-          /* line 547, ../scss/components/_soe_dm_issue.scss */
           .view-stanford-magazine-article-issue- .mag-article-issue-container [class*="mag-issue-color-"] .mag-article-issue-content-container .mag-article-issue-more:after {
             background-size: 35px 26px;
             vertical-align: -20%; } }
         @media (max-width: 480px) {
-          /* line 547, ../scss/components/_soe_dm_issue.scss */
           .view-stanford-magazine-article-issue- .mag-article-issue-container [class*="mag-issue-color-"] .mag-article-issue-content-container .mag-article-issue-more:after {
             background-size: 31px 23px;
             vertical-align: -32%; } }
-    /* line 568, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-article-issue- .mag-article-issue-container .mag-article-issue-text {
       color: #FFFFFF;
       font-size: 1em;
@@ -5400,82 +4676,66 @@ p.infotext {
       width: 100%;
       margin-bottom: 30px; }
       @media (max-width: 480px) {
-        /* line 568, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-article-issue- .mag-article-issue-container .mag-article-issue-text {
           bottom: 115px; } }
-    /* line 582, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-article-issue- .mag-article-issue-container .mag-issue-color-orange a {
       background: #FFBD54; }
-    /* line 586, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-article-issue- .mag-article-issue-container .mag-issue-color-turquoise a {
       background: #00ECE9; }
-    /* line 590, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-article-issue- .mag-article-issue-container .mag-issue-color-pink a {
       background: #FF525C; }
 
-/* line 599, ../scss/components/_soe_dm_issue.scss */
 .view-stanford-magazine-issue-recent.views-grid-three .views-row {
   margin-right: 4.49%;
   margin-bottom: 4.49%;
   width: 30%; }
-  /* line 604, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent.views-grid-three .views-row:nth-child(3), .view-stanford-magazine-issue-recent.views-grid-three .views-row:nth-child(6) {
     margin-right: 0; }
   @media (max-width: 1200px) {
-    /* line 599, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issue-recent.views-grid-three .views-row {
       width: 47.4%; }
-      /* line 611, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issue-recent.views-grid-three .views-row:nth-child(2), .view-stanford-magazine-issue-recent.views-grid-three .views-row:nth-child(4), .view-stanford-magazine-issue-recent.views-grid-three .views-row:nth-child(6) {
         margin-right: 0; }
-      /* line 617, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issue-recent.views-grid-three .views-row:nth-child(3) {
         margin-right: 4.49%; } }
   @media (max-width: 767px) {
-    /* line 599, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issue-recent.views-grid-three .views-row {
       margin-right: 4%;
       margin-bottom: 4%; }
-      /* line 625, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issue-recent.views-grid-three .views-row:nth-child(3) {
         margin-right: 4%; } }
   @media (max-width: 480px) {
-    /* line 599, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issue-recent.views-grid-three .views-row {
       width: 100%;
       margin-right: 0; }
-      /* line 633, ../scss/components/_soe_dm_issue.scss */
       .view-stanford-magazine-issue-recent.views-grid-three .views-row:nth-child(3) {
         margin-right: 0; } }
-/* line 639, ../scss/components/_soe_dm_issue.scss */
+
 .view-stanford-magazine-issue-recent h2 {
   text-align: center;
   margin: 1.8em 0 0.2em; }
-/* line 644, ../scss/components/_soe_dm_issue.scss */
+
 .view-stanford-magazine-issue-recent h3 {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 400;
   color: #606060;
   text-align: center;
   margin: 0 0 40px; }
-/* line 652, ../scss/components/_soe_dm_issue.scss */
+
 .view-stanford-magazine-issue-recent .view-content {
   width: 75%;
   margin: 0 auto; }
   @media (max-width: 979px) {
-    /* line 652, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issue-recent .view-content {
       width: 100%; } }
-/* line 660, ../scss/components/_soe_dm_issue.scss */
+
 .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper {
   position: relative; }
-  /* line 663, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper:hover img {
     -webkit-transform: scale(1.03);
     -moz-transform: scale(1.03);
     -o-transform: scale(1.03);
     transform: scale(1.03); }
-  /* line 667, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper .prev-mag-issue-title {
     font-family: "Roboto Slab", serif;
     color: #000000;
@@ -5485,59 +4745,47 @@ p.infotext {
     left: calc(50% - 70px);
     padding: 10px 30px;
     z-index: 1; }
-  /* line 678, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper .prev-mag-issue-image {
     overflow: hidden; }
-    /* line 681, ../scss/components/_soe_dm_issue.scss */
     .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper .prev-mag-issue-image img {
       -webkit-transition: all 1s ease;
       -moz-transition: all 1s ease;
       -o-transition: all 1s ease;
       transition: all 1s ease; }
       @media (max-width: 767px) {
-        /* line 681, ../scss/components/_soe_dm_issue.scss */
         .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper .prev-mag-issue-image img {
           width: 100%; } }
-  /* line 689, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper.prev-mag-issue-color-orange .prev-mag-issue-title {
     background: #FFBD54; }
-  /* line 693, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper.prev-mag-issue-color-turquoise .prev-mag-issue-title {
     background: #00ECE9; }
-  /* line 697, ../scss/components/_soe_dm_issue.scss */
   .view-stanford-magazine-issue-recent a .prev-mag-issue-wrapper.prev-mag-issue-color-pink .prev-mag-issue-title {
     background: #FF525C; }
 
-/* line 704, ../scss/components/_soe_dm_issue.scss */
 .block-stanford-soe-helper-magazine h2 {
   display: none; }
-/* line 708, ../scss/components/_soe_dm_issue.scss */
+
 .block-stanford-soe-helper-magazine .soe_block_align {
   text-align: center; }
-  /* line 711, ../scss/components/_soe_dm_issue.scss */
   .block-stanford-soe-helper-magazine .soe_block_align a.btn {
     margin: 0 0 80px; }
 
-/* line 722, ../scss/components/_soe_dm_issue.scss */
 .page-magazine .view-stanford-magazine-issue-most-recent .views-row,
 .page-magazine-collections .view-stanford-magazine-issue-most-recent .views-row {
   margin-bottom: 0; }
-/* line 726, ../scss/components/_soe_dm_issue.scss */
+
 .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container,
 .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container {
   position: relative; }
-  /* line 729, ../scss/components/_soe_dm_issue.scss */
   .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container img,
   .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container img {
     object-fit: cover;
     object-position: center center;
     width: 100%;
     height: 100vh; }
-    /* line 735, ../scss/components/_soe_dm_issue.scss */
     .logged-in .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container img, .logged-in
     .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container img {
       height: calc(100vh - 75px); }
-  /* line 740, ../scss/components/_soe_dm_issue.scss */
   .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container,
   .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container {
     color: #FFFFFF;
@@ -5546,7 +4794,6 @@ p.infotext {
     text-align: center;
     width: 100%;
     z-index: 1; }
-    /* line 748, ../scss/components/_soe_dm_issue.scss */
     .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1,
     .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1 {
       color: #000000;
@@ -5555,11 +4802,9 @@ p.infotext {
       padding: 18px 30px;
       background: rgba(0, 0, 0, 0.3); }
       @media (max-width: 767px) {
-        /* line 748, ../scss/components/_soe_dm_issue.scss */
         .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1,
         .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1 {
           display: block; } }
-      /* line 758, ../scss/components/_soe_dm_issue.scss */
       .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1:after,
       .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1:after {
         content: "";
@@ -5570,39 +4815,31 @@ p.infotext {
         padding-left: 41px;
         margin-left: 12px; }
         @media (max-width: 767px) {
-          /* line 758, ../scss/components/_soe_dm_issue.scss */
           .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1:after,
           .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1:after {
             vertical-align: -14%; } }
         @media (max-width: 480px) {
-          /* line 758, ../scss/components/_soe_dm_issue.scss */
           .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1:after,
           .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1:after {
             background-size: 31px 23px;
             vertical-align: -25%; } }
-      /* line 775, ../scss/components/_soe_dm_issue.scss */
       .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-orange,
       .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-orange {
         background: #FFBD54; }
-      /* line 779, ../scss/components/_soe_dm_issue.scss */
       .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-turquoise,
       .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-turquoise {
         background: #00ECE9; }
-      /* line 783, ../scss/components/_soe_dm_issue.scss */
       .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-pink,
       .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container h1.mag-issue-color-pink {
         background: #FF525C; }
-    /* line 788, ../scss/components/_soe_dm_issue.scss */
     .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container p,
     .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container p {
       margin: 10% 0 80px; }
-    /* line 792, ../scss/components/_soe_dm_issue.scss */
     .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container:after,
     .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container:after {
       content: url("../img/soe_chevron_down_white.png");
       position: absolute;
       bottom: 50px; }
-  /* line 799, ../scss/components/_soe_dm_issue.scss */
   .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container:after,
   .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container:after {
     content: '';
@@ -5617,43 +4854,36 @@ p.infotext {
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=  '#00000000', endColorstr='#BF000000', GradientType=0); }
 
-/* line 9, ../scss/components/_soe_dm_curtain_reveal.scss */
 html.js body > div[class*="hero"]:not([class*="reveal"]) img {
   object-fit: cover;
   object-position: center center;
   width: 100%;
   height: 100vh; }
-/* line 16, ../scss/components/_soe_dm_curtain_reveal.scss */
+
 html.js body > .hero-curtain {
   background: transparent;
   position: relative; }
-  /* line 20, ../scss/components/_soe_dm_curtain_reveal.scss */
   html.js body > .hero-curtain > * {
     position: relative;
     z-index: 10; }
-  /* line 25, ../scss/components/_soe_dm_curtain_reveal.scss */
   html.js body > .hero-curtain .entity {
     background: #000; }
-  /* line 29, ../scss/components/_soe_dm_curtain_reveal.scss */
   html.js body > .hero-curtain.below-hero {
     padding-bottom: 0 !important; }
-  /* line 33, ../scss/components/_soe_dm_curtain_reveal.scss */
   html.js body > .hero-curtain .mag-feat-image-container {
     background: #333333; }
-/* line 38, ../scss/components/_soe_dm_curtain_reveal.scss */
+
 html.js body > .hero-curtain-reveal {
   position: fixed;
   top: 0;
   width: 100%; }
-  /* line 43, ../scss/components/_soe_dm_curtain_reveal.scss */
   html.js body > .hero-curtain-reveal.below-hero {
     position: relative; }
 
 @media (max-width: 767px) {
-  /* line 12, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-ds-extras-stanford-page-title {
     margin-bottom: 0; } }
-/* line 18, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-image-container div:first-child.page-cta-link-container {
   bottom: 0;
   float: right;
@@ -5663,33 +4893,27 @@ html.js body > .hero-curtain-reveal {
   margin-top: 40px;
   position: relative; }
   @media (max-width: 767px) {
-    /* line 18, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-image-container div:first-child.page-cta-link-container {
       margin-bottom: 20px;
       margin-top: 20px; } }
-/* line 33, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay {
   margin-left: 3%;
   margin-right: auto;
   position: relative;
   width: auto; }
   @media (max-width: 1050px) {
-    /* line 33, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay {
       height: auto;
       margin-left: auto;
       position: inherit;
       width: 100%; } }
-  /* line 46, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-turquoise a {
     text-decoration-color: #FFBD54; }
-  /* line 50, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-orange a {
     text-decoration-color: #FF525C; }
-  /* line 54, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-pink a {
     text-decoration-color: #00ECE9; }
-  /* line 58, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay > div {
     background: #FFFFFF;
     bottom: 48px;
@@ -5703,169 +4927,143 @@ html.js body > .hero-curtain-reveal {
     position: absolute;
     top: auto;
     width: 50%; }
-    /* line 68, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay > div > div:first-child {
       border-top-style: solid;
       border-width: 6px;
       margin-right: 72%;
       padding-top: 20px; }
-    /* line 75, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay > div > div:first-child.top-banner-orange {
       border-top-color: #FFBD54; }
-    /* line 79, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay > div > div:first-child.top-banner-pink {
       border-top-color: #FF525C; }
-    /* line 83, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay > div > div:first-child.top-banner-turquoise {
       border-top-color: #00ECE9; }
     @media (max-width: 1050px) {
-      /* line 58, ../scss/components/_soe_page.scss */
       .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay > div {
         bottom: 88px;
         max-width: 100%;
         position: inherit;
         width: 100%; } }
-/* line 97, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-top {
   position: absolute;
   top: 240px; }
   @media (max-width: 950px) {
-    /* line 97, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-top {
       position: relative;
       top: 88px;
       max-width: 100%; } }
-/* line 108, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right {
   float: left;
   margin-right: 10%;
   min-width: 1440px; }
-  /* line 113, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right > div {
     float: right;
     position: relative;
     right: -100px;
     top: -240px; }
     @media (max-width: 1400px) {
-      /* line 113, ../scss/components/_soe_page.scss */
       .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right > div {
         top: -300px; } }
     @media (max-width: 1050px) {
-      /* line 113, ../scss/components/_soe_page.scss */
       .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right > div {
         position: relative;
         right: 0;
         top: -80px;
         width: 100%; } }
-/* line 134, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right.top-banner-top {
   right: 0;
   top: 190px; }
   @media (max-width: 1050px) {
-    /* line 134, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right.top-banner-top {
       top: 170px; } }
-  /* line 143, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right.top-banner-top > div {
     float: right;
     position: relative;
     top: -140px; }
     @media (max-width: 1050px) {
-      /* line 143, ../scss/components/_soe_page.scss */
       .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right.top-banner-top > div {
         position: relative;
         right: 0;
         top: -170px;
         width: 100%; } }
-/* line 158, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right.top-banner-bottom {
   right: 0;
   position: absolute; }
   @media (max-width: 1050px) {
-    /* line 158, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right.top-banner-bottom {
       float: left;
       min-width: auto;
       position: relative; } }
-  /* line 169, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right.top-banner-bottom > div {
     float: right;
     position: relative;
     top: -240px; }
     @media (max-width: 1050px) {
-      /* line 169, ../scss/components/_soe_page.scss */
       .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-right.top-banner-bottom > div {
         position: relative;
         top: 0;
         width: 100%; } }
-/* line 183, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-top {
   top: 280px;
   min-width: 1440px; }
   @media (max-width: 1050px) {
-    /* line 183, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .banner-overlay.top-banner-top {
       float: left;
       min-width: auto;
       position: relative;
       top: 88px; } }
-/* line 195, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container {
   background: #FFFFFF;
   color: #333333; }
-  /* line 199, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container p {
     font-size: 0.9em;
     line-height: 1.3em;
     margin-bottom: 20px; }
-  /* line 205, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container p:last-child {
     margin-bottom: 0px; }
-  /* line 209, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container a {
     color: #333333;
     text-decoration: underline; }
-  /* line 214, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container a:hover {
     text-decoration-color: #333333; }
-  /* line 218, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container a.btn {
     text-decoration: none; }
-  /* line 222, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container .btn a:hover,
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container a.btn:hover {
     background-color: #333333;
     color: #FFFFFF; }
   @media (max-width: 767px) {
-    /* line 195, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container {
       margin-top: 0;
       margin-bottom: 0; } }
   @media (max-width: 480px) {
-    /* line 195, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container {
       width: 90%; } }
-/* line 240, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container h2 {
   font-size: 1.3em;
   letter-spacing: 0; }
   @media (max-width: 910px) {
-    /* line 240, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container h2 {
       font-size: 1em; } }
   @media (max-width: 580px) {
-    /* line 240, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container h2 {
       font-size: .8em; } }
+
 @media (max-width: 910px) {
-  /* line 255, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container h3 {
     font-size: 1em; } }
+
 @media (max-width: 580px) {
-  /* line 255, ../scss/components/_soe_page.scss */
   .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-feat-caption-container h3 {
     font-size: .8em; } }
-/* line 267, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-cta-link-container {
   bottom: 100px;
   float: right;
@@ -5874,32 +5072,27 @@ html.js body > .hero-curtain-reveal {
   margin-right: 8%;
   position: relative; }
   @media (max-width: 480px) {
-    /* line 267, ../scss/components/_soe_page.scss */
     .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-cta-link-container {
       bottom: 60px; }
-      /* line 279, ../scss/components/_soe_page.scss */
       .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-cta-link-container a {
         font-size: 1.7rem; } }
-/* line 285, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .page-cta-link-container.right {
   float: left;
   width: 100%; }
-/* line 290, ../scss/components/_soe_page.scss */
+
 .node-type-stanford-page #block-views-stanford-page-top-banner-block .views-row {
   margin-bottom: 0; }
 
-/* line 11, ../scss/components/_soe_people_spotlight.scss */
 .node-type-stanford-people-spotlight .main {
   padding-top: 0; }
-/* line 15, ../scss/components/_soe_people_spotlight.scss */
+
 .node-type-stanford-people-spotlight .group-s-ppl-spot-container {
   width: 65%;
   margin: 0 auto; }
   @media (max-width: 480px) {
-    /* line 15, ../scss/components/_soe_people_spotlight.scss */
     .node-type-stanford-people-spotlight .group-s-ppl-spot-container {
       width: 100%; } }
-  /* line 22, ../scss/components/_soe_people_spotlight.scss */
   .node-type-stanford-people-spotlight .group-s-ppl-spot-container .field-name-field-s-ppl-spot-date {
     font-size: 0.9em;
     color: #606060;
@@ -5907,16 +5100,12 @@ html.js body > .hero-curtain-reveal {
     font-style: italic;
     display: flex;
     justify-content: flex-end; }
-    /* line 31, ../scss/components/_soe_people_spotlight.scss */
     .node-type-stanford-people-spotlight .group-s-ppl-spot-container .field-name-field-s-ppl-spot-date .field-item:before {
       content: "Story originally published\00a0"; }
-  /* line 38, ../scss/components/_soe_people_spotlight.scss */
   .node-type-stanford-people-spotlight .group-s-ppl-spot-container .field-name-field-s-ppl-spot-quote .field-item:before {
     content: open-quote; }
-  /* line 44, ../scss/components/_soe_people_spotlight.scss */
   .node-type-stanford-people-spotlight .group-s-ppl-spot-container .field-name-body p:last-child:after {
     content: close-quote; }
-  /* line 49, ../scss/components/_soe_people_spotlight.scss */
   .node-type-stanford-people-spotlight .group-s-ppl-spot-container .field-name-field-s-ppl-spot-photo-credit {
     font-size: 0.9em;
     color: #606060;
@@ -5924,118 +5113,96 @@ html.js body > .hero-curtain-reveal {
     border-top: 1px solid #D7D7D7;
     padding-top: 5px;
     margin-top: 40px; }
-    /* line 58, ../scss/components/_soe_people_spotlight.scss */
     .node-type-stanford-people-spotlight .group-s-ppl-spot-container .field-name-field-s-ppl-spot-photo-credit .field-item:before {
       content: "Photo credit: \00a0"; }
 
-/* line 69, ../scss/components/_soe_people_spotlight.scss */
 .view-stanford-people-spotlight-h-card .spotlight-container {
   background: #FFFFFF;
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 73, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-all-content-container {
     display: flex;
     justify-content: center;
     align-items: center;
     width: 85%;
     margin: 0 auto;
-    padding: 50px 0; }
+    padding: 50px 40px; }
     @media (max-width: 767px) {
-      /* line 73, ../scss/components/_soe_people_spotlight.scss */
       .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-all-content-container {
-        width: 100%; } }
+        width: auto; } }
     @media (max-width: 650px) {
-      /* line 73, ../scss/components/_soe_people_spotlight.scss */
       .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-all-content-container {
         display: block; } }
-  /* line 88, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-img {
     margin-right: 40px;
     flex-shrink: 0; }
     @media (max-width: 650px) {
-      /* line 88, ../scss/components/_soe_people_spotlight.scss */
       .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-img {
         text-align: center;
         margin-right: 0; } }
-    /* line 96, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-img img {
       border-radius: 50%;
       border-width: 5px;
       border-style: solid; }
-    /* line 102, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-img.spotlight-img-color-orange img {
       border-color: #FFBD54; }
-    /* line 106, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-img.spotlight-img-color-turquoise img {
       border-color: #00ECE9; }
-    /* line 110, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-img.spotlight-img-color-pink img {
       border-color: #FF525C; }
   @media (max-width: 650px) {
-    /* line 115, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container {
-      padding: 30px 20px; } }
-  /* line 121, ../scss/components/_soe_people_spotlight.scss */
+      padding: 10px 20px 0; } }
   .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a {
     text-decoration: underline;
     -webkit-text-decoration-skip: ink;
     text-decoration-skip: ink; }
-    /* line 125, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:focus, .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
-  /* line 131, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-name h2 {
     margin: 0 0 20px; }
     @media (max-width: 767px) {
-      /* line 131, ../scss/components/_soe_people_spotlight.scss */
       .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-name h2 {
         margin-top: 15px; } }
-  /* line 138, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a {
     -webkit-text-decoration-color: #FFBD54;
     text-decoration-color: #FFBD54; }
-  /* line 142, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a {
     -webkit-text-decoration-color: #00ECE9;
     text-decoration-color: #00ECE9; }
-  /* line 146, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a {
     -webkit-text-decoration-color: #FF525C;
     text-decoration-color: #FF525C; }
-  /* line 151, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-degree p,
   .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-title p {
     font-size: 0.9em;
     line-height: 1.3em;
     margin: 0; }
-  /* line 158, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-department p {
     font-size: 0.9em;
     line-height: 1.3em;
     margin-top: 0; }
-  /* line 164, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-quote {
     font-family: "Roboto Slab", serif;
     font-size: 1.2em;
     font-weight: 600; }
-    /* line 169, ../scss/components/_soe_people_spotlight.scss */
+    @media (max-width: 650px) {
+      .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-quote p {
+        margin-bottom: 0; } }
     .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-quote p:before {
       content: open-quote; }
-    /* line 173, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spotlight-h-card .spotlight-container .spotlight-info-container .spotlight-quote p:after {
       content: close-quote; }
 
-/* line 188, ../scss/components/_soe_people_spotlight.scss */
 .view-stanford-people-spot-1-vertical-span6-card .view-content,
 .view-stanford-people-spotlight-1-v-span4-card .view-content,
 .view-stanford-ppl-spot-2-v-span4-card .view-content,
 .view-stanford-ppl-spot-2-v-span6-card .view-content,
 .view-stanford-ppl-spot-3-v-card .view-content {
   clear: both; }
-/* line 192, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-people-spot-1-vertical-span6-card .view-filters,
 .view-stanford-people-spotlight-1-v-span4-card .view-filters,
 .view-stanford-ppl-spot-2-v-span4-card .view-filters,
@@ -6043,7 +5210,6 @@ html.js body > .hero-curtain-reveal {
 .view-stanford-ppl-spot-3-v-card .view-filters {
   float: right;
   clear: both; }
-  /* line 195, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spot-1-vertical-span6-card .view-filters select,
   .view-stanford-people-spotlight-1-v-span4-card .view-filters select,
   .view-stanford-ppl-spot-2-v-span4-card .view-filters select,
@@ -6053,7 +5219,6 @@ html.js body > .hero-curtain-reveal {
     -webkit-border-radius: 0 0 0 0;
     -moz-border-radius: 0 0 0 0;
     border-radius: 0 0 0 0; }
-    /* line 198, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spot-1-vertical-span6-card .view-filters select option,
     .view-stanford-people-spotlight-1-v-span4-card .view-filters select option,
     .view-stanford-ppl-spot-2-v-span4-card .view-filters select option,
@@ -6063,7 +5228,7 @@ html.js body > .hero-curtain-reveal {
       font-weight: 400;
       font-size: 18px;
       color: #333333; }
-/* line 206, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-people-spot-1-vertical-span6-card.views-grid-three .views-row,
 .view-stanford-people-spotlight-1-v-span4-card.views-grid-three .views-row,
 .view-stanford-ppl-spot-2-v-span4-card.views-grid-three .views-row,
@@ -6071,7 +5236,6 @@ html.js body > .hero-curtain-reveal {
 .view-stanford-ppl-spot-3-v-card.views-grid-three .views-row {
   margin-bottom: 80px; }
   @media (max-width: 1200px) {
-    /* line 206, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spot-1-vertical-span6-card.views-grid-three .views-row,
     .view-stanford-people-spotlight-1-v-span4-card.views-grid-three .views-row,
     .view-stanford-ppl-spot-2-v-span4-card.views-grid-three .views-row,
@@ -6079,14 +5243,13 @@ html.js body > .hero-curtain-reveal {
     .view-stanford-ppl-spot-3-v-card.views-grid-three .views-row {
       width: 46.1%; } }
   @media (max-width: 580px) {
-    /* line 206, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spot-1-vertical-span6-card.views-grid-three .views-row,
     .view-stanford-people-spotlight-1-v-span4-card.views-grid-three .views-row,
     .view-stanford-ppl-spot-2-v-span4-card.views-grid-three .views-row,
     .view-stanford-ppl-spot-2-v-span6-card.views-grid-three .views-row,
     .view-stanford-ppl-spot-3-v-card.views-grid-three .views-row {
       width: 96.2%; } }
-/* line 217, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-people-spot-1-vertical-span6-card .spotlight-container,
 .view-stanford-people-spotlight-1-v-span4-card .spotlight-container,
 .view-stanford-ppl-spot-2-v-span4-card .spotlight-container,
@@ -6096,7 +5259,6 @@ html.js body > .hero-curtain-reveal {
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2); }
-  /* line 221, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-all-content-container,
   .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-all-content-container,
   .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-all-content-container,
@@ -6104,7 +5266,6 @@ html.js body > .hero-curtain-reveal {
   .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-all-content-container {
     margin: 0 auto;
     padding: 36px 40px 50px; }
-  /* line 226, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-img,
   .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-img,
   .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-img,
@@ -6112,14 +5273,12 @@ html.js body > .hero-curtain-reveal {
   .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-img {
     text-align: center; }
     @media (max-width: 650px) {
-      /* line 226, ../scss/components/_soe_people_spotlight.scss */
       .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-img,
       .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-img,
       .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-img,
       .view-stanford-ppl-spot-2-v-span6-card .spotlight-container .spotlight-img,
       .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-img {
         margin-right: 0; } }
-    /* line 232, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-img img,
     .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-img img,
     .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-img img,
@@ -6128,28 +5287,24 @@ html.js body > .hero-curtain-reveal {
       border-radius: 50%;
       border-width: 5px;
       border-style: solid; }
-    /* line 238, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-img.spotlight-img-color-orange img,
     .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-img.spotlight-img-color-orange img,
     .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-img.spotlight-img-color-orange img,
     .view-stanford-ppl-spot-2-v-span6-card .spotlight-container .spotlight-img.spotlight-img-color-orange img,
     .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-img.spotlight-img-color-orange img {
       border-color: #FFBD54; }
-    /* line 242, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
     .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
     .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
     .view-stanford-ppl-spot-2-v-span6-card .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
     .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-img.spotlight-img-color-turquoise img {
       border-color: #00ECE9; }
-    /* line 246, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-img.spotlight-img-color-pink img,
     .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-img.spotlight-img-color-pink img,
     .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-img.spotlight-img-color-pink img,
     .view-stanford-ppl-spot-2-v-span6-card .spotlight-container .spotlight-img.spotlight-img-color-pink img,
     .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-img.spotlight-img-color-pink img {
       border-color: #FF525C; }
-  /* line 253, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a,
   .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a,
   .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a,
@@ -6158,7 +5313,6 @@ html.js body > .hero-curtain-reveal {
     text-decoration: underline;
     -webkit-text-decoration-skip: ink;
     text-decoration-skip: ink; }
-    /* line 257, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:focus, .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover,
     .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:focus,
     .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover,
@@ -6170,7 +5324,6 @@ html.js body > .hero-curtain-reveal {
     .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
-  /* line 263, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-name h2,
   .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name h2,
   .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name h2,
@@ -6178,7 +5331,6 @@ html.js body > .hero-curtain-reveal {
   .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-info-container .spotlight-name h2 {
     font-size: 1.3em;
     margin: 25px 0 10px; }
-  /* line 268, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a,
   .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a,
   .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a,
@@ -6186,7 +5338,6 @@ html.js body > .hero-curtain-reveal {
   .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a {
     -webkit-text-decoration-color: #FFBD54;
     text-decoration-color: #FFBD54; }
-  /* line 272, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a,
   .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a,
   .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a,
@@ -6194,7 +5345,6 @@ html.js body > .hero-curtain-reveal {
   .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a {
     -webkit-text-decoration-color: #00ECE9;
     text-decoration-color: #00ECE9; }
-  /* line 276, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a,
   .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a,
   .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a,
@@ -6202,7 +5352,6 @@ html.js body > .hero-curtain-reveal {
   .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a {
     -webkit-text-decoration-color: #FF525C;
     text-decoration-color: #FF525C; }
-  /* line 281, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-degree p,
   .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-title p,
   .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-degree p,
@@ -6216,7 +5365,6 @@ html.js body > .hero-curtain-reveal {
     font-size: 0.9em;
     line-height: 1.3em;
     margin: 0; }
-  /* line 288, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-department p,
   .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-department p,
   .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-info-container .spotlight-department p,
@@ -6225,7 +5373,6 @@ html.js body > .hero-curtain-reveal {
     font-size: 0.9em;
     line-height: 1.3em;
     margin-top: 0; }
-  /* line 294, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-quote,
   .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-quote,
   .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-info-container .spotlight-quote,
@@ -6234,14 +5381,12 @@ html.js body > .hero-curtain-reveal {
     font-family: "Roboto Slab", serif;
     font-size: 1.2em;
     font-weight: 600; }
-    /* line 299, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-quote p:before,
     .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-quote p:before,
     .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-info-container .spotlight-quote p:before,
     .view-stanford-ppl-spot-2-v-span6-card .spotlight-container .spotlight-info-container .spotlight-quote p:before,
     .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-info-container .spotlight-quote p:before {
       content: open-quote; }
-    /* line 303, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-people-spot-1-vertical-span6-card .spotlight-container .spotlight-info-container .spotlight-quote p:after,
     .view-stanford-people-spotlight-1-v-span4-card .spotlight-container .spotlight-info-container .spotlight-quote p:after,
     .view-stanford-ppl-spot-2-v-span4-card .spotlight-container .spotlight-info-container .spotlight-quote p:after,
@@ -6249,13 +5394,12 @@ html.js body > .hero-curtain-reveal {
     .view-stanford-ppl-spot-3-v-card .spotlight-container .spotlight-info-container .spotlight-quote p:after {
       content: close-quote; }
 
-/* line 319, ../scss/components/_soe_people_spotlight.scss */
 .front .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container, .front
 .view-stanford-people-spotlight-fw-banner .spotlight-container, .front
 .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container, .front
 .view-stanford-ppl-spot-fw-banner-quote .spotlight-container {
   background: #FFFFFF; }
-/* line 323, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
 .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
 .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
@@ -6266,28 +5410,24 @@ html.js body > .hero-curtain-reveal {
   margin: 0 auto;
   padding: 70px 0 0; }
   @media (max-width: 1900px) {
-    /* line 323, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
     .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       width: 65%; } }
   @media (max-width: 1400px) {
-    /* line 323, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
     .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       width: 85%; } }
   @media (max-width: 1200px) {
-    /* line 323, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
     .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       width: 90%; } }
   @media (max-width: 767px) {
-    /* line 323, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
@@ -6297,7 +5437,6 @@ html.js body > .hero-curtain-reveal {
       width: 90%;
       padding: 50px 0 0; } }
   @media (max-width: 500px) {
-    /* line 323, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
@@ -6305,13 +5444,12 @@ html.js body > .hero-curtain-reveal {
       display: block;
       text-align: center;
       width: 100%; } }
-  /* line 350, ../scss/components/_soe_people_spotlight.scss */
   .front .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container, .front
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .front
   .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .front
   .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
     padding: 70px 0; }
-/* line 355, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img,
 .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img,
 .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img,
@@ -6319,7 +5457,6 @@ html.js body > .hero-curtain-reveal {
   margin-right: 40px;
   flex-shrink: 0; }
   @media (max-width: 767px) {
-    /* line 355, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img,
@@ -6327,14 +5464,12 @@ html.js body > .hero-curtain-reveal {
       margin-right: 0;
       width: 286px; } }
   @media (max-width: 580px) {
-    /* line 355, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img,
     .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
       width: 200px; } }
   @media (max-width: 500px) {
-    /* line 355, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img,
@@ -6342,7 +5477,6 @@ html.js body > .hero-curtain-reveal {
       flex-shrink: 0;
       margin: 0 auto;
       width: 60%; } }
-  /* line 371, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img img,
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img,
   .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img,
@@ -6351,38 +5485,33 @@ html.js body > .hero-curtain-reveal {
     border-width: 8px;
     border-style: solid; }
     @media (max-width: 767px) {
-      /* line 371, ../scss/components/_soe_people_spotlight.scss */
       .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img img,
       .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img,
       .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img,
       .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
         max-width: 82%; } }
     @media (max-width: 500px) {
-      /* line 371, ../scss/components/_soe_people_spotlight.scss */
       .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img img,
       .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img,
       .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img,
       .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
         border-width: 6px; } }
-  /* line 383, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img.spotlight-img-color-orange img,
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-orange img,
   .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-orange img,
   .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-orange img {
     border-color: #FFBD54; }
-  /* line 387, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
   .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
   .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-turquoise img {
     border-color: #00ECE9; }
-  /* line 391, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img.spotlight-img-color-pink img,
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-pink img,
   .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-pink img,
   .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-pink img {
     border-color: #FF525C; }
-/* line 398, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a,
 .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a,
 .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a,
@@ -6390,7 +5519,6 @@ html.js body > .hero-curtain-reveal {
   text-decoration: underline;
   -webkit-text-decoration-skip: ink;
   text-decoration-skip: ink; }
-  /* line 402, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:focus, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover,
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:focus,
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover,
@@ -6400,7 +5528,7 @@ html.js body > .hero-curtain-reveal {
   .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*="spotlight-name-color-"] a:hover {
     -webkit-text-decoration-color: #333333;
     text-decoration-color: #333333; }
-/* line 408, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2,
 .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2,
 .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2,
@@ -6408,7 +5536,6 @@ html.js body > .hero-curtain-reveal {
   font-size: 2.4em;
   margin: 0 0 20px; }
   @media (max-width: 767px) {
-    /* line 408, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2,
@@ -6416,41 +5543,39 @@ html.js body > .hero-curtain-reveal {
       margin-top: 15px;
       font-size: 1.7em; } }
   @media (max-width: 580px) {
-    /* line 408, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2,
     .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
       font-size: 1.4em; } }
   @media (max-width: 480px) {
-    /* line 408, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2,
     .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
       margin-bottom: 4px; } }
-/* line 423, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a,
 .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a,
 .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a,
 .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a {
   -webkit-text-decoration-color: #FFBD54;
   text-decoration-color: #FFBD54; }
-/* line 427, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a,
 .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a,
 .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a,
 .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a {
   -webkit-text-decoration-color: #00ECE9;
   text-decoration-color: #00ECE9; }
-/* line 431, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a,
 .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a,
 .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a,
 .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a {
   -webkit-text-decoration-color: #FF525C;
   text-decoration-color: #FF525C; }
-/* line 436, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-degree p,
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-department p,
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-title p,
@@ -6466,7 +5591,6 @@ html.js body > .hero-curtain-reveal {
   font-size: 1.2em;
   margin: 0; }
   @media (max-width: 767px) {
-    /* line 436, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-degree p,
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-department p,
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-title p,
@@ -6480,7 +5604,7 @@ html.js body > .hero-curtain-reveal {
     .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-department p,
     .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-title p {
       font-size: 1em; } }
-/* line 446, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote,
 .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote,
 .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote,
@@ -6491,14 +5615,12 @@ html.js body > .hero-curtain-reveal {
   line-height: 1.3em;
   margin-top: 20px; }
   @media (max-width: 580px) {
-    /* line 446, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote,
     .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
       font-size: 1.2em; } }
   @media (max-width: 500px) {
-    /* line 446, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote,
@@ -6506,26 +5628,22 @@ html.js body > .hero-curtain-reveal {
       width: 80%;
       margin: 20px auto; } }
   @media (max-width: 480px) {
-    /* line 446, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote,
     .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote,
     .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote,
     .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
       font-size: 1em; } }
-  /* line 464, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote p:before,
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote p:before,
   .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote p:before,
   .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote p:before {
     content: open-quote; }
-  /* line 468, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote p:after,
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote p:after,
   .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote p:after,
   .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote p:after {
     content: close-quote; }
 
-/* line 481, ../scss/components/_soe_people_spotlight.scss */
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .view-content .views-row-1.views-row {
   display: flex;
   align-items: center;
@@ -6533,179 +5651,155 @@ html.js body > .hero-curtain-reveal {
   margin: 0 auto;
   padding: 70px 0 0; }
   @media (max-width: 1900px) {
-    /* line 481, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .view-content .views-row-1.views-row {
       width: 100%; } }
   @media (max-width: 1900px) {
-    /* line 490, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .view-content .views-row-1.views-row .spotlight-all-content-container {
       width: 100%; } }
   @media (max-width: 1400px) {
-    /* line 481, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .view-content .views-row-1.views-row {
       width: 95%; } }
   @media (max-width: 1200px) {
-    /* line 481, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .view-content .views-row-1.views-row {
       width: 100%; } }
   @media (max-width: 767px) {
-    /* line 481, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .view-content .views-row-1.views-row {
       display: flex;
       text-align: left;
       width: 100%;
       padding: 50px 0 0; } }
   @media (max-width: 500px) {
-    /* line 481, ../scss/components/_soe_people_spotlight.scss */
     .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .view-content .views-row-1.views-row {
       display: block;
       text-align: center;
       width: 100%; } }
-  /* line 513, ../scss/components/_soe_people_spotlight.scss */
   .front .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .view-content .views-row-1.views-row {
     padding: 70px 0; }
-/* line 518, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container {
   background: #F8F8F8;
   box-shadow: none; }
-/* line 522, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot :nth-child(2) {
   order: inherit; }
 
-/* line 527, ../scss/components/_soe_people_spotlight.scss */
 .view-stanford-ppl-spot-3-v-card,
 .view-stanford-ppl-spot-3-card-and-banner {
   display: flex;
   flex-direction: column; }
 
-/* line 532, ../scss/components/_soe_people_spotlight.scss */
 .view-stanford-ppl-spot-3-v-card :nth-child(1) {
   order: 2; }
 
-/* line 535, ../scss/components/_soe_people_spotlight.scss */
 .view-stanford-ppl-spot-3-v-card :nth-child(2) {
   order: 1; }
 
-/* line 538, ../scss/components/_soe_people_spotlight.scss */
 .view-stanford-ppl-spot-3-v-card :nth-child(3) {
   order: 3; }
 
-/* line 541, ../scss/components/_soe_people_spotlight.scss */
 .view-stanford-ppl-spot-3-v-card :nth-child(4) {
   order: 4; }
 
-/* line 546, ../scss/components/_soe_people_spotlight.scss */
 .view-stanford-ppl-spot-3-v-card.view-display-id-block_related :nth-child(1) {
   order: 1; }
-/* line 549, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.view-display-id-block_related :nth-child(2) {
   order: 2; }
-/* line 552, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.view-display-id-block_related :nth-child(3) {
   order: 3; }
-/* line 555, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.view-display-id-block_related :nth-child(4) {
   order: 4; }
-/* line 558, ../scss/components/_soe_people_spotlight.scss */
+
 .view-stanford-ppl-spot-3-v-card.view-display-id-block_related .view-footer {
   text-align: center; }
 
-/* line 566, ../scss/components/_soe_people_spotlight.scss */
 .spotlight-button {
   text-align: center;
   margin-top: 30px; }
-  /* line 570, ../scss/components/_soe_people_spotlight.scss */
   .spotlight-button[class*="spotlight-img-color-"] a {
     color: #000000; }
-    /* line 573, ../scss/components/_soe_people_spotlight.scss */
     .spotlight-button[class*="spotlight-img-color-"] a:focus, .spotlight-button[class*="spotlight-img-color-"] a:hover {
       color: #FFFFFF;
       background: #333333; }
-  /* line 580, ../scss/components/_soe_people_spotlight.scss */
   .spotlight-button.spotlight-img-color-orange a {
     background: #FFBD54; }
-    /* line 583, ../scss/components/_soe_people_spotlight.scss */
     .front .spotlight-button.spotlight-img-color-orange a {
       color: #FFFFFF;
       background: #B1040E; }
-      /* line 587, ../scss/components/_soe_people_spotlight.scss */
       .front .spotlight-button.spotlight-img-color-orange a:focus, .front .spotlight-button.spotlight-img-color-orange a:hover {
         background: #333333; }
-  /* line 594, ../scss/components/_soe_people_spotlight.scss */
   .spotlight-button.spotlight-img-color-turquoise a {
     background: #00ECE9; }
-    /* line 597, ../scss/components/_soe_people_spotlight.scss */
     .front .spotlight-button.spotlight-img-color-turquoise a {
       color: #FFFFFF;
       background: #B1040E; }
-      /* line 601, ../scss/components/_soe_people_spotlight.scss */
       .front .spotlight-button.spotlight-img-color-turquoise a:focus, .front .spotlight-button.spotlight-img-color-turquoise a:hover {
         background: #333333; }
-  /* line 608, ../scss/components/_soe_people_spotlight.scss */
   .spotlight-button.spotlight-img-color-pink a {
     background: #FF525C; }
-    /* line 611, ../scss/components/_soe_people_spotlight.scss */
     .front .spotlight-button.spotlight-img-color-pink a {
       color: #FFFFFF;
       background: #B1040E; }
-      /* line 615, ../scss/components/_soe_people_spotlight.scss */
       .front .spotlight-button.spotlight-img-color-pink a:focus, .front .spotlight-button.spotlight-img-color-pink a:hover {
         background: #333333; }
-  /* line 622, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spot-1-vertical-span6-card .spotlight-button, .view-stanford-people-spotlight-1-v-span4-card .spotlight-button, .view-stanford-ppl-spot-2-v-span4-card .spotlight-button, .view-stanford-ppl-spot-2-v-span6-card .spotlight-button {
+  .view-stanford-people-spot-1-vertical-span6-card .spotlight-button,
+  .view-stanford-people-spotlight-1-v-span4-card .spotlight-button,
+  .view-stanford-ppl-spot-2-v-span4-card .spotlight-button,
+  .view-stanford-ppl-spot-2-v-span6-card .spotlight-button {
     clear: both; }
-  /* line 629, ../scss/components/_soe_people_spotlight.scss */
-  #content-body .content .view-stanford-people-spot-1-vertical-span6-card .spotlight-button a.btn, #content-body .content .view-stanford-people-spotlight-1-v-span4-card .spotlight-button a.btn, .view-stanford-people-spot-1-vertical-span6-card .spotlight-button a, .view-stanford-people-spotlight-1-v-span4-card .spotlight-button a {
+  #content-body .content .view-stanford-people-spot-1-vertical-span6-card .spotlight-button a.btn,
+  #content-body .content .view-stanford-people-spotlight-1-v-span4-card .spotlight-button a.btn,
+  .view-stanford-people-spot-1-vertical-span6-card .spotlight-button a,
+  .view-stanford-people-spotlight-1-v-span4-card .spotlight-button a {
     display: block;
     width: auto; }
-  /* line 637, ../scss/components/_soe_people_spotlight.scss */
-  #content-body .content .view-stanford-ppl-spot-2-v-span4-card .spotlight-button a.btn, #content-body .content .view-stanford-ppl-spot-2-v-span6-card .spotlight-button a.btn, .view-stanford-ppl-spot-2-v-span4-card .spotlight-button a, .view-stanford-ppl-spot-2-v-span6-card .spotlight-button a {
+  #content-body .content .view-stanford-ppl-spot-2-v-span4-card .spotlight-button a.btn,
+  #content-body .content .view-stanford-ppl-spot-2-v-span6-card .spotlight-button a.btn,
+  .view-stanford-ppl-spot-2-v-span4-card .spotlight-button a,
+  .view-stanford-ppl-spot-2-v-span6-card .spotlight-button a {
     display: block;
     width: 30%;
     margin: 0 auto; }
     @media (max-width: 767px) {
-      /* line 637, ../scss/components/_soe_people_spotlight.scss */
-      #content-body .content .view-stanford-ppl-spot-2-v-span4-card .spotlight-button a.btn, #content-body .content .view-stanford-ppl-spot-2-v-span6-card .spotlight-button a.btn, .view-stanford-ppl-spot-2-v-span4-card .spotlight-button a, .view-stanford-ppl-spot-2-v-span6-card .spotlight-button a {
+      #content-body .content .view-stanford-ppl-spot-2-v-span4-card .spotlight-button a.btn,
+      #content-body .content .view-stanford-ppl-spot-2-v-span6-card .spotlight-button a.btn,
+      .view-stanford-ppl-spot-2-v-span4-card .spotlight-button a,
+      .view-stanford-ppl-spot-2-v-span6-card .spotlight-button a {
         width: auto; } }
 
-/* line 652, ../scss/components/_soe_people_spotlight.scss */
 .main.spotlight #content-head {
   margin-bottom: 0; }
-/* line 659, ../scss/components/_soe_people_spotlight.scss */
+
 .main.spotlight #content-body #views-exposed-form-stanford-ppl-spot-3-v-card-page-1 .views-exposed-form #edit-field-s-ppl-spot-affiliation-tid-wrapper {
   padding-right: 20px; }
-/* line 663, ../scss/components/_soe_people_spotlight.scss */
+
 .main.spotlight #content-body #views-exposed-form-stanford-ppl-spot-3-v-card-page-1 .views-exposed-form .views-exposed-widget {
   padding-right: 0; }
   @media (max-width: 1200px) {
-    /* line 663, ../scss/components/_soe_people_spotlight.scss */
     .main.spotlight #content-body #views-exposed-form-stanford-ppl-spot-3-v-card-page-1 .views-exposed-form .views-exposed-widget {
       padding-right: 1em; } }
   @media (max-width: 979px) {
-    /* line 663, ../scss/components/_soe_people_spotlight.scss */
     .main.spotlight #content-body #views-exposed-form-stanford-ppl-spot-3-v-card-page-1 .views-exposed-form .views-exposed-widget {
       padding-right: 0.8em; } }
   @media (max-width: 767px) {
-    /* line 663, ../scss/components/_soe_people_spotlight.scss */
     .main.spotlight #content-body #views-exposed-form-stanford-ppl-spot-3-v-card-page-1 .views-exposed-form .views-exposed-widget {
       padding-right: 0.7em; } }
   @media (max-width: 580px) {
-    /* line 663, ../scss/components/_soe_people_spotlight.scss */
     .main.spotlight #content-body #views-exposed-form-stanford-ppl-spot-3-v-card-page-1 .views-exposed-form .views-exposed-widget {
       padding-right: 0.5em; } }
-/* line 686, ../scss/components/_soe_people_spotlight.scss */
+
 .main.spotlight #content-body .view-stanford-ppl-spot-3-v-card .views-row-first {
   padding-top: 0; }
-  /* line 689, ../scss/components/_soe_people_spotlight.scss */
   .main.spotlight #content-body .view-stanford-ppl-spot-3-v-card .views-row-first .spotlight-all-content-container {
     margin-bottom: 0;
     padding-top: 36px; }
-/* line 696, ../scss/components/_soe_people_spotlight.scss */
+
 .main.spotlight #content-body .attachment .view-stanford-ppl-spot-3-v-card .views-row-first .spotlight-all-content-container {
   margin-bottom: 60px;
   padding-top: 0; }
 
-/* line 703, ../scss/components/_soe_people_spotlight.scss */
 #block-views-005720ec0398a13d1a26b9de441e83ca > h2 {
   text-align: center;
   padding-bottom: 30px; }

--- a/css/soe_helper_print.css
+++ b/css/soe_helper_print.css
@@ -1,5 +1,4 @@
 @import url(https://fonts.googleapis.com/css?family=Roboto+Slab:400,700,300,100);
-/* line 11, ../scss/components/_soe_print.scss */
 .print-breadcrumb,
 .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-accent-color,
 .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-dept,
@@ -12,72 +11,55 @@
 .print-source_url {
   display: none; }
 
-/* line 24, ../scss/components/_soe_print.scss */
 .print-logo {
   width: 82%;
   margin: 0 auto; }
-  /* line 28, ../scss/components/_soe_print.scss */
   .print-logo img {
     width: 25%;
     height: auto;
     margin-top: 40px; }
 
-/* line 35, ../scss/components/_soe_print.scss */
 .print-content {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif; }
-  /* line 38, ../scss/components/_soe_print.scss */
   .print-content .paragraphs-item-p-wysiwyg-simple {
     width: 100%; }
-  /* line 43, ../scss/components/_soe_print.scss */
   .print-content .node-stanford-magazine-article h2,
   .print-content .node-stanford-magazine-article h3,
   .print-content .node-stanford-magazine-article h4 {
     font-family: "Roboto Slab", serif; }
-  /* line 49, ../scss/components/_soe_print.scss */
   .print-content .node-stanford-magazine-article h2 {
     font-size: 20px;
     margin-top: 30px; }
-    /* line 53, ../scss/components/_soe_print.scss */
     .print-content .node-stanford-magazine-article h2:first-child {
       font-size: 26px;
       line-height: 1.2em;
       width: 90%;
       margin: 40px auto 10px; }
-  /* line 61, ../scss/components/_soe_print.scss */
   .print-content .node-stanford-magazine-article h3 {
     font-size: 16px; }
-  /* line 65, ../scss/components/_soe_print.scss */
   .print-content .node-stanford-magazine-article h4 {
     font-size: 13px; }
-  /* line 69, ../scss/components/_soe_print.scss */
   .print-content .node-stanford-magazine-article p {
     font-size: 13px;
     line-height: 18px; }
-  /* line 74, ../scss/components/_soe_print.scss */
   .print-content .node-stanford-magazine-article .content {
     width: 90%;
     margin: 0 auto; }
-  /* line 79, ../scss/components/_soe_print.scss */
   .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-topics {
     width: 100%;
     margin: 0 auto; }
-    /* line 83, ../scss/components/_soe_print.scss */
     .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-topics .field-items {
       display: inline-flex; }
-      /* line 87, ../scss/components/_soe_print.scss */
       .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-topics .field-items .field-item a:after {
         content: ", \00a0";
         color: #333333; }
-      /* line 92, ../scss/components/_soe_print.scss */
       .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-topics .field-items .field-item:last-child a:after {
         content: none; }
-    /* line 98, ../scss/components/_soe_print.scss */
     .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-topics a {
       color: #B1040E;
       font-size: 13px;
       font-weight: 300;
       margin: 0 auto 18px; }
-  /* line 106, ../scss/components/_soe_print.scss */
   .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-byline,
   .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-date {
     color: #606060;
@@ -85,22 +67,17 @@
     font-weight: 300;
     display: inline-flex;
     margin: 0 auto 32px; }
-  /* line 115, ../scss/components/_soe_print.scss */
   .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-date {
     margin-left: 0; }
-    /* line 118, ../scss/components/_soe_print.scss */
     .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-date .field-item:after {
       content: "\00a0 | \00a0"; }
-  /* line 123, ../scss/components/_soe_print.scss */
   .print-content .node-stanford-magazine-article .field-name-field-s-mag-article-dek {
     font-size: 18px;
     line-height: 1.3em;
     margin: 20px auto 22px;
     width: 90%; }
-  /* line 130, ../scss/components/_soe_print.scss */
   .print-content .node-stanford-magazine-article .field-name-body {
     margin: 0 auto; }
-    /* line 133, ../scss/components/_soe_print.scss */
     .print-content .node-stanford-magazine-article .field-name-body .caption {
       color: #606060;
       font-size: 9px;

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   },
   "devDependencies": {
     "grunt": "^1.0.1",
-    "grunt-contrib-sass": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
-    "grunt-sass": "^2.0.0"
+    "grunt-sass": "^2.1.0"
+  },
+  "dependencies": {
+    "node-sass": "^4.9.3"
   }
 }

--- a/scss/components/_soe_people_spotlight.scss
+++ b/scss/components/_soe_people_spotlight.scss
@@ -76,9 +76,9 @@
       align-items: center;
       width: 85%;
       margin: 0 auto;
-      padding: 50px 0;
+      padding: 50px 40px;
       @include breakpoint-max(small) {
-        width: 100%;
+        width: auto;
       }
       @media (max-width: 650px) {
         display: block;
@@ -114,7 +114,7 @@
 
     .spotlight-info-container {
       @media (max-width: 650px) {
-        padding: 30px 20px;
+        padding: 10px 20px 0;
       }
 
       .spotlight-name {
@@ -165,6 +165,12 @@
         font-family: $roboto-slab;
         font-size: em(24px);
         font-weight: 600;
+
+        p {
+          @media (max-width: 650px) {
+            margin-bottom: 0;
+          }
+        }
 
         p:before {
           content: open-quote;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Addressed responsive bigs for horizontal spotlights
- Cleaned up Grunts tasks (and package.json file) to avoid the need of Ruby (reduce command line errors when running Grunt)

# Needed By (Date)
- End of sprint

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. On this page, `get-involved/alumni`, ensure that the horizontal postcard block is repsonsive (addressed the issues beginning at `767px` and that padding issue is cleaned up

# Affected Projects or Products
- SoE
- stanford_soe_helper

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-3304

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)