### PR TITLE
SOE-3477: added Image Caption CSS

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -319,7 +319,7 @@ th {
 .region-fullwidth-top #block-ds-extras-featured-image img {
   width: 100%; }
 
-/* line 8, ../scss/components/_soe_wysiwyg.scss */
+/* line 6, ../scss/components/_soe_wysiwyg.scss */
 .image-caption-right,
 .image-caption-left {
   margin: 0px;
@@ -332,21 +332,21 @@ th {
   line-height: 1.3em;
   font-weight: 300; }
 
-/* line 21, ../scss/components/_soe_wysiwyg.scss */
+/* line 19, ../scss/components/_soe_wysiwyg.scss */
 .image-caption-right {
   float: right;
   width: 10em;
   padding: 0em 0em 0em 1.5em;
   margin: 1em 0em 1em 1.5em; }
 
-/* line 28, ../scss/components/_soe_wysiwyg.scss */
+/* line 26, ../scss/components/_soe_wysiwyg.scss */
 .image-caption-left {
   float: left;
   width: 10em;
   padding: 0em 1.5em 0em 0em;
   margin: 1em 1.5em 0em 0em; }
 
-/* line 35, ../scss/components/_soe_wysiwyg.scss */
+/* line 33, ../scss/components/_soe_wysiwyg.scss */
 .summary {
   font-family: "Roboto Slab", serif;
   font-size: 1.6em;
@@ -354,63 +354,63 @@ th {
   line-height: 1.5em;
   margin-bottom: 40px; }
   @media (max-width: 1200px) {
-    /* line 35, ../scss/components/_soe_wysiwyg.scss */
+    /* line 33, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.4em; } }
   @media (max-width: 979px) {
-    /* line 35, ../scss/components/_soe_wysiwyg.scss */
+    /* line 33, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.3em; } }
   @media (max-width: 767px) {
-    /* line 35, ../scss/components/_soe_wysiwyg.scss */
+    /* line 33, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.2em; } }
   @media (max-width: 480px) {
-    /* line 35, ../scss/components/_soe_wysiwyg.scss */
+    /* line 33, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.1em; } }
 
-/* line 60, ../scss/components/_soe_wysiwyg.scss */
+/* line 58, ../scss/components/_soe_wysiwyg.scss */
 a[class*='btn-'] {
   color: #000000; }
-  /* line 63, ../scss/components/_soe_wysiwyg.scss */
+  /* line 61, ../scss/components/_soe_wysiwyg.scss */
   .node-type-stanford-event a[class*='btn-'] {
     color: #ffffff; }
-/* line 68, ../scss/components/_soe_wysiwyg.scss */
+/* line 66, ../scss/components/_soe_wysiwyg.scss */
 a.btn-orange {
   background: #ffbd54; }
-/* line 72, ../scss/components/_soe_wysiwyg.scss */
+/* line 70, ../scss/components/_soe_wysiwyg.scss */
 a.btn-turquoise {
   background: #00ece9; }
-/* line 76, ../scss/components/_soe_wysiwyg.scss */
+/* line 74, ../scss/components/_soe_wysiwyg.scss */
 a.btn-pink {
   background: #ff525c; }
-/* line 81, ../scss/components/_soe_wysiwyg.scss */
+/* line 79, ../scss/components/_soe_wysiwyg.scss */
 a.external-link:after {
   content: url("../img/soe_external_link_icon_red.svg");
   padding-left: 5px;
   vertical-align: -2%; }
-/* line 87, ../scss/components/_soe_wysiwyg.scss */
+/* line 85, ../scss/components/_soe_wysiwyg.scss */
 a.external-link:focus:after, a.external-link:hover:after {
   content: url("../img/soe_external_link_icon_black.svg"); }
-/* line 93, ../scss/components/_soe_wysiwyg.scss */
+/* line 91, ../scss/components/_soe_wysiwyg.scss */
 a.btn.external-link:after {
   content: url("../img/soe_external_link_icon_white.svg");
   padding-left: 5px;
   vertical-align: -2%; }
-/* line 100, ../scss/components/_soe_wysiwyg.scss */
+/* line 98, ../scss/components/_soe_wysiwyg.scss */
 a[class*='btn-'].btn.external-link:after {
   content: url("../img/soe_external_link_icon_black.svg");
   padding-left: 5px;
   vertical-align: -2%; }
-/* line 106, ../scss/components/_soe_wysiwyg.scss */
+/* line 104, ../scss/components/_soe_wysiwyg.scss */
 a[class*='btn-'].btn.external-link:focus:after, a[class*='btn-'].btn.external-link:hover:after {
   content: url("../img/soe_external_link_icon_white.svg"); }
-/* line 112, ../scss/components/_soe_wysiwyg.scss */
+/* line 110, ../scss/components/_soe_wysiwyg.scss */
 a.private-link, .private-link a {
   font-size: 18px;
   font-weight: 400; }
-  /* line 117, ../scss/components/_soe_wysiwyg.scss */
+  /* line 115, ../scss/components/_soe_wysiwyg.scss */
   a.private-link:after, .private-link a:after {
     background-image: url("../img/soe_lock_black.svg");
     background-size: 13px 16px;
@@ -418,21 +418,21 @@ a.private-link, .private-link a {
     padding-left: 13px;
     margin-left: 5px; }
 
-/* line 127, ../scss/components/_soe_wysiwyg.scss */
+/* line 125, ../scss/components/_soe_wysiwyg.scss */
 p.btn-center {
   text-align: center; }
-  /* line 130, ../scss/components/_soe_wysiwyg.scss */
+  /* line 128, ../scss/components/_soe_wysiwyg.scss */
   p.btn-center a.btn {
     margin-right: 40px; }
     @media (max-width: 767px) {
-      /* line 130, ../scss/components/_soe_wysiwyg.scss */
+      /* line 128, ../scss/components/_soe_wysiwyg.scss */
       p.btn-center a.btn {
         margin-right: 10px; } }
-    /* line 137, ../scss/components/_soe_wysiwyg.scss */
+    /* line 135, ../scss/components/_soe_wysiwyg.scss */
     p.btn-center a.btn:last-child {
       margin-right: 0; }
 
-/* line 143, ../scss/components/_soe_wysiwyg.scss */
+/* line 141, ../scss/components/_soe_wysiwyg.scss */
 p.highlight {
   -webkit-column-count: 1;
   -moz-column-count: 1;
@@ -444,7 +444,7 @@ p.highlight {
   line-height: 1.6em;
   padding: 0 50px; }
 
-/* line 153, ../scss/components/_soe_wysiwyg.scss */
+/* line 151, ../scss/components/_soe_wysiwyg.scss */
 p.columns {
   -webkit-column-count: 1;
   -moz-column-count: 1;
@@ -457,12 +457,12 @@ p.columns {
   line-height: 1.6em;
   font-weight: bold; }
   @media (max-width: 767px) {
-    /* line 153, ../scss/components/_soe_wysiwyg.scss */
+    /* line 151, ../scss/components/_soe_wysiwyg.scss */
     p.columns {
       -webkit-column-count: 1;
       -moz-column-count: 1;
       column-count: 1; } }
-  /* line 165, ../scss/components/_soe_wysiwyg.scss */
+  /* line 163, ../scss/components/_soe_wysiwyg.scss */
   .group-p-ws-style p.columns {
     -webkit-column-count: 1;
     -moz-column-count: 1;
@@ -470,7 +470,7 @@ p.columns {
     font-size: 1.2em;
     line-height: 1.6em;
     padding: 0 50px; }
-    /* line 171, ../scss/components/_soe_wysiwyg.scss */
+    /* line 169, ../scss/components/_soe_wysiwyg.scss */
     .group-p-ws-style p.columns p.columns {
       -webkit-column-count: 1;
       -moz-column-count: 1;
@@ -479,7 +479,7 @@ p.columns {
       line-height: 1.6em;
       padding: 0 50px; }
 
-/* line 180, ../scss/components/_soe_wysiwyg.scss */
+/* line 178, ../scss/components/_soe_wysiwyg.scss */
 p.float-left,
 p.float-right {
   float: none;
@@ -487,7 +487,7 @@ p.float-right {
   padding: 0px;
   width: 100%; }
 
-/* line 192, ../scss/components/_soe_wysiwyg.scss */
+/* line 190, ../scss/components/_soe_wysiwyg.scss */
 p.related-link {
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
@@ -495,37 +495,37 @@ p.related-link {
   background: #ffffff;
   line-height: 1.3em;
   padding: 27px 36px 30px; }
-  /* line 198, ../scss/components/_soe_wysiwyg.scss */
+  /* line 196, ../scss/components/_soe_wysiwyg.scss */
   p.related-link a {
     text-decoration: none; }
-    /* line 201, ../scss/components/_soe_wysiwyg.scss */
+    /* line 199, ../scss/components/_soe_wysiwyg.scss */
     p.related-link a:focus, p.related-link a:hover {
       text-decoration: underline; }
-  /* line 207, ../scss/components/_soe_wysiwyg.scss */
+  /* line 205, ../scss/components/_soe_wysiwyg.scss */
   p.related-link:before {
     content: 'Related \00a0 | \00a0';
     font-weight: 600; }
 
-/* line 214, ../scss/components/_soe_wysiwyg.scss */
+/* line 212, ../scss/components/_soe_wysiwyg.scss */
 p.summary.drop-cap:first-letter {
   padding: 25px 10px 0 0;
   font-size: 2.875em;
   font-weight: 600;
   float: left; }
   @media (max-width: 1200px) {
-    /* line 214, ../scss/components/_soe_wysiwyg.scss */
+    /* line 212, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 21px 10px 0 0; } }
   @media (max-width: 979px) {
-    /* line 214, ../scss/components/_soe_wysiwyg.scss */
+    /* line 212, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 16px 10px 0 0; } }
   @media (max-width: 480px) {
-    /* line 214, ../scss/components/_soe_wysiwyg.scss */
+    /* line 212, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 15px 10px 0 0; } }
 
-/* line 234, ../scss/components/_soe_wysiwyg.scss */
+/* line 232, ../scss/components/_soe_wysiwyg.scss */
 .caption {
   color: #606060;
   font-weight: 300;
@@ -534,24 +534,24 @@ p.summary.drop-cap:first-letter {
   text-align: center;
   margin: 0 2em 4em; }
 
-/* line 244, ../scss/components/_soe_wysiwyg.scss */
+/* line 242, ../scss/components/_soe_wysiwyg.scss */
 .main table {
   width: 100%;
   margin-bottom: 2em; }
-/* line 250, ../scss/components/_soe_wysiwyg.scss */
+/* line 248, ../scss/components/_soe_wysiwyg.scss */
 .main p.float-left {
   margin-right: 15px; }
-/* line 254, ../scss/components/_soe_wysiwyg.scss */
+/* line 252, ../scss/components/_soe_wysiwyg.scss */
 .main p.float-right {
   margin-left: 15px; }
 
 @media (max-width: 767px) {
-  /* line 261, ../scss/components/_soe_wysiwyg.scss */
+  /* line 259, ../scss/components/_soe_wysiwyg.scss */
   .field-type-text-long h2, .field-type-text-with-summary h2 {
     font-size: 1.2em; } }
 
 @media (max-width: 767px) {
-  /* line 270, ../scss/components/_soe_wysiwyg.scss */
+  /* line 268, ../scss/components/_soe_wysiwyg.scss */
   .field-type-text-long h3, .field-type-text-with-summary h3 {
     font-size: 1em; } }
 

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -319,7 +319,34 @@ th {
 .region-fullwidth-top #block-ds-extras-featured-image img {
   width: 100%; }
 
-/* line 6, ../scss/components/_soe_wysiwyg.scss */
+/* line 8, ../scss/components/_soe_wysiwyg.scss */
+.image-caption-right,
+.image-caption-left {
+  margin: 0px;
+  padding: 0px;
+  border: 0;
+  float: none;
+  width: 100%;
+  color: #606060;
+  font-size: 16px;
+  line-height: 1.3em;
+  font-weight: 300; }
+
+/* line 21, ../scss/components/_soe_wysiwyg.scss */
+.image-caption-right {
+  float: right;
+  width: 10em;
+  padding: 0em 0em 0em 1.5em;
+  margin: 1em 0em 1em 1.5em; }
+
+/* line 28, ../scss/components/_soe_wysiwyg.scss */
+.image-caption-left {
+  float: left;
+  width: 10em;
+  padding: 0em 1.5em 0em 0em;
+  margin: 1em 1.5em 0em 0em; }
+
+/* line 35, ../scss/components/_soe_wysiwyg.scss */
 .summary {
   font-family: "Roboto Slab", serif;
   font-size: 1.6em;
@@ -327,63 +354,63 @@ th {
   line-height: 1.5em;
   margin-bottom: 40px; }
   @media (max-width: 1200px) {
-    /* line 6, ../scss/components/_soe_wysiwyg.scss */
+    /* line 35, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.4em; } }
   @media (max-width: 979px) {
-    /* line 6, ../scss/components/_soe_wysiwyg.scss */
+    /* line 35, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.3em; } }
   @media (max-width: 767px) {
-    /* line 6, ../scss/components/_soe_wysiwyg.scss */
+    /* line 35, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.2em; } }
   @media (max-width: 480px) {
-    /* line 6, ../scss/components/_soe_wysiwyg.scss */
+    /* line 35, ../scss/components/_soe_wysiwyg.scss */
     .summary {
       font-size: 1.1em; } }
 
-/* line 31, ../scss/components/_soe_wysiwyg.scss */
+/* line 60, ../scss/components/_soe_wysiwyg.scss */
 a[class*='btn-'] {
   color: #000000; }
-  /* line 34, ../scss/components/_soe_wysiwyg.scss */
+  /* line 63, ../scss/components/_soe_wysiwyg.scss */
   .node-type-stanford-event a[class*='btn-'] {
     color: #ffffff; }
-/* line 39, ../scss/components/_soe_wysiwyg.scss */
+/* line 68, ../scss/components/_soe_wysiwyg.scss */
 a.btn-orange {
   background: #ffbd54; }
-/* line 43, ../scss/components/_soe_wysiwyg.scss */
+/* line 72, ../scss/components/_soe_wysiwyg.scss */
 a.btn-turquoise {
   background: #00ece9; }
-/* line 47, ../scss/components/_soe_wysiwyg.scss */
+/* line 76, ../scss/components/_soe_wysiwyg.scss */
 a.btn-pink {
   background: #ff525c; }
-/* line 52, ../scss/components/_soe_wysiwyg.scss */
+/* line 81, ../scss/components/_soe_wysiwyg.scss */
 a.external-link:after {
   content: url("../img/soe_external_link_icon_red.svg");
   padding-left: 5px;
   vertical-align: -2%; }
-/* line 58, ../scss/components/_soe_wysiwyg.scss */
+/* line 87, ../scss/components/_soe_wysiwyg.scss */
 a.external-link:focus:after, a.external-link:hover:after {
   content: url("../img/soe_external_link_icon_black.svg"); }
-/* line 64, ../scss/components/_soe_wysiwyg.scss */
+/* line 93, ../scss/components/_soe_wysiwyg.scss */
 a.btn.external-link:after {
   content: url("../img/soe_external_link_icon_white.svg");
   padding-left: 5px;
   vertical-align: -2%; }
-/* line 71, ../scss/components/_soe_wysiwyg.scss */
+/* line 100, ../scss/components/_soe_wysiwyg.scss */
 a[class*='btn-'].btn.external-link:after {
   content: url("../img/soe_external_link_icon_black.svg");
   padding-left: 5px;
   vertical-align: -2%; }
-/* line 77, ../scss/components/_soe_wysiwyg.scss */
+/* line 106, ../scss/components/_soe_wysiwyg.scss */
 a[class*='btn-'].btn.external-link:focus:after, a[class*='btn-'].btn.external-link:hover:after {
   content: url("../img/soe_external_link_icon_white.svg"); }
-/* line 83, ../scss/components/_soe_wysiwyg.scss */
+/* line 112, ../scss/components/_soe_wysiwyg.scss */
 a.private-link, .private-link a {
   font-size: 18px;
   font-weight: 400; }
-  /* line 88, ../scss/components/_soe_wysiwyg.scss */
+  /* line 117, ../scss/components/_soe_wysiwyg.scss */
   a.private-link:after, .private-link a:after {
     background-image: url("../img/soe_lock_black.svg");
     background-size: 13px 16px;
@@ -391,21 +418,21 @@ a.private-link, .private-link a {
     padding-left: 13px;
     margin-left: 5px; }
 
-/* line 98, ../scss/components/_soe_wysiwyg.scss */
+/* line 127, ../scss/components/_soe_wysiwyg.scss */
 p.btn-center {
   text-align: center; }
-  /* line 101, ../scss/components/_soe_wysiwyg.scss */
+  /* line 130, ../scss/components/_soe_wysiwyg.scss */
   p.btn-center a.btn {
     margin-right: 40px; }
     @media (max-width: 767px) {
-      /* line 101, ../scss/components/_soe_wysiwyg.scss */
+      /* line 130, ../scss/components/_soe_wysiwyg.scss */
       p.btn-center a.btn {
         margin-right: 10px; } }
-    /* line 108, ../scss/components/_soe_wysiwyg.scss */
+    /* line 137, ../scss/components/_soe_wysiwyg.scss */
     p.btn-center a.btn:last-child {
       margin-right: 0; }
 
-/* line 114, ../scss/components/_soe_wysiwyg.scss */
+/* line 143, ../scss/components/_soe_wysiwyg.scss */
 p.highlight {
   -webkit-column-count: 1;
   -moz-column-count: 1;
@@ -417,7 +444,7 @@ p.highlight {
   line-height: 1.6em;
   padding: 0 50px; }
 
-/* line 124, ../scss/components/_soe_wysiwyg.scss */
+/* line 153, ../scss/components/_soe_wysiwyg.scss */
 p.columns {
   -webkit-column-count: 1;
   -moz-column-count: 1;
@@ -430,12 +457,12 @@ p.columns {
   line-height: 1.6em;
   font-weight: bold; }
   @media (max-width: 767px) {
-    /* line 124, ../scss/components/_soe_wysiwyg.scss */
+    /* line 153, ../scss/components/_soe_wysiwyg.scss */
     p.columns {
       -webkit-column-count: 1;
       -moz-column-count: 1;
       column-count: 1; } }
-  /* line 136, ../scss/components/_soe_wysiwyg.scss */
+  /* line 165, ../scss/components/_soe_wysiwyg.scss */
   .group-p-ws-style p.columns {
     -webkit-column-count: 1;
     -moz-column-count: 1;
@@ -443,7 +470,7 @@ p.columns {
     font-size: 1.2em;
     line-height: 1.6em;
     padding: 0 50px; }
-    /* line 142, ../scss/components/_soe_wysiwyg.scss */
+    /* line 171, ../scss/components/_soe_wysiwyg.scss */
     .group-p-ws-style p.columns p.columns {
       -webkit-column-count: 1;
       -moz-column-count: 1;
@@ -452,7 +479,15 @@ p.columns {
       line-height: 1.6em;
       padding: 0 50px; }
 
-/* line 151, ../scss/components/_soe_wysiwyg.scss */
+/* line 180, ../scss/components/_soe_wysiwyg.scss */
+p.float-left,
+p.float-right {
+  float: none;
+  margin: 0px;
+  padding: 0px;
+  width: 100%; }
+
+/* line 192, ../scss/components/_soe_wysiwyg.scss */
 p.related-link {
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
@@ -460,37 +495,37 @@ p.related-link {
   background: #ffffff;
   line-height: 1.3em;
   padding: 27px 36px 30px; }
-  /* line 157, ../scss/components/_soe_wysiwyg.scss */
+  /* line 198, ../scss/components/_soe_wysiwyg.scss */
   p.related-link a {
     text-decoration: none; }
-    /* line 160, ../scss/components/_soe_wysiwyg.scss */
+    /* line 201, ../scss/components/_soe_wysiwyg.scss */
     p.related-link a:focus, p.related-link a:hover {
       text-decoration: underline; }
-  /* line 166, ../scss/components/_soe_wysiwyg.scss */
+  /* line 207, ../scss/components/_soe_wysiwyg.scss */
   p.related-link:before {
     content: 'Related \00a0 | \00a0';
     font-weight: 600; }
 
-/* line 173, ../scss/components/_soe_wysiwyg.scss */
+/* line 214, ../scss/components/_soe_wysiwyg.scss */
 p.summary.drop-cap:first-letter {
   padding: 25px 10px 0 0;
   font-size: 2.875em;
   font-weight: 600;
   float: left; }
   @media (max-width: 1200px) {
-    /* line 173, ../scss/components/_soe_wysiwyg.scss */
+    /* line 214, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 21px 10px 0 0; } }
   @media (max-width: 979px) {
-    /* line 173, ../scss/components/_soe_wysiwyg.scss */
+    /* line 214, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 16px 10px 0 0; } }
   @media (max-width: 480px) {
-    /* line 173, ../scss/components/_soe_wysiwyg.scss */
+    /* line 214, ../scss/components/_soe_wysiwyg.scss */
     p.summary.drop-cap:first-letter {
       padding: 15px 10px 0 0; } }
 
-/* line 193, ../scss/components/_soe_wysiwyg.scss */
+/* line 234, ../scss/components/_soe_wysiwyg.scss */
 .caption {
   color: #606060;
   font-weight: 300;
@@ -499,24 +534,24 @@ p.summary.drop-cap:first-letter {
   text-align: center;
   margin: 0 2em 4em; }
 
-/* line 203, ../scss/components/_soe_wysiwyg.scss */
+/* line 244, ../scss/components/_soe_wysiwyg.scss */
 .main table {
   width: 100%;
   margin-bottom: 2em; }
-/* line 209, ../scss/components/_soe_wysiwyg.scss */
+/* line 250, ../scss/components/_soe_wysiwyg.scss */
 .main p.float-left {
   margin-right: 15px; }
-/* line 213, ../scss/components/_soe_wysiwyg.scss */
+/* line 254, ../scss/components/_soe_wysiwyg.scss */
 .main p.float-right {
   margin-left: 15px; }
 
 @media (max-width: 767px) {
-  /* line 220, ../scss/components/_soe_wysiwyg.scss */
+  /* line 261, ../scss/components/_soe_wysiwyg.scss */
   .field-type-text-long h2, .field-type-text-with-summary h2 {
     font-size: 1.2em; } }
 
 @media (max-width: 767px) {
-  /* line 229, ../scss/components/_soe_wysiwyg.scss */
+  /* line 270, ../scss/components/_soe_wysiwyg.scss */
   .field-type-text-long h3, .field-type-text-with-summary h3 {
     font-size: 1em; } }
 
@@ -2493,28 +2528,15 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
 .span4 .bean-stanford-postcard-linked .postcard-linked-container, .span5 .bean-stanford-postcard-linked .postcard,
 .span5 .bean-stanford-postcard-linked .postcard-linked-container, .span6 .bean-stanford-postcard-linked .postcard,
 .span6 .bean-stanford-postcard-linked .postcard-linked-container, .span7 .bean-stanford-postcard-linked .postcard,
-.span7 .bean-stanford-postcard-linked .postcard-linked-container, .span1
-.bean-stanford-postcard.view-mode-single_centered_button .postcard,
-.span1
-.bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span2
-.bean-stanford-postcard.view-mode-single_centered_button .postcard,
-.span2
-.bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span3
-.bean-stanford-postcard.view-mode-single_centered_button .postcard,
-.span3
-.bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span4
-.bean-stanford-postcard.view-mode-single_centered_button .postcard,
-.span4
-.bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span5
-.bean-stanford-postcard.view-mode-single_centered_button .postcard,
-.span5
-.bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span6
-.bean-stanford-postcard.view-mode-single_centered_button .postcard,
-.span6
-.bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span7
-.bean-stanford-postcard.view-mode-single_centered_button .postcard,
-.span7
-.bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container {
+.span7 .bean-stanford-postcard-linked .postcard-linked-container,
+.span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard,
+.span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard,
+.span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard,
+.span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard,
+.span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard,
+.span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard,
+.span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container, .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard,
+.span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container {
   display: block;
   padding: 0; }
   /* line 331, ../scss/components/_soe_beans.scss */
@@ -2539,56 +2561,29 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   .span6 .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container, .span7 .bean-stanford-postcard-linked .postcard .postcard-image,
   .span7 .bean-stanford-postcard-linked .postcard .postcard-linked-img-container,
   .span7 .bean-stanford-postcard-linked .postcard-linked-container .postcard-image,
-  .span7 .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container, .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
-  .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
-  .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
-  .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
-  .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
-  .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
-  .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
-  .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
-  .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
-  .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
-  .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
-  .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
-  .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
-  .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
-  .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
-  .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
-  .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
-  .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
-  .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
-  .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
-  .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
-  .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container {
+  .span7 .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img-container,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
+  .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
+  .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
+  .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
+  .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
+  .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
+  .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
+  .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
+  .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
+  .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
+  .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
+  .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
+  .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
+  .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
+  .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
+  .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container, .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-image,
+  .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img-container,
+  .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-image,
+  .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img-container {
     margin-right: 0; }
   /* line 338, ../scss/components/_soe_beans.scss */
   .span1 .bean-stanford-postcard-linked .postcard .image-container .field-name-field-s-post-link-image img,
@@ -2612,56 +2607,29 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   .span6 .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span7 .bean-stanford-postcard-linked .postcard .image-container .field-name-field-s-post-link-image img,
   .span7 .bean-stanford-postcard-linked .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
   .span7 .bean-stanford-postcard-linked .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span7 .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
-  .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
-  .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
-  .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
-  .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
-  .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
-  .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
-  .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
-  .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
-  .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
-  .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
-  .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
-  .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
-  .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
-  .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
-  .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img {
+  .span7 .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
+  .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
+  .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
+  .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
+  .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
+  .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
+  .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
+  .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
+  .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
+  .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
+  .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img, .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard .image-container .field-name-field-s-post-link-image img,
+  .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-img .field-name-field-s-post-link-image img,
+  .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .image-container .field-name-field-s-post-link-image img,
+  .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-img .field-name-field-s-post-link-image img {
     width: 100%; }
   /* line 343, ../scss/components/_soe_beans.scss */
   .span1 .bean-stanford-postcard-linked .postcard .postcard-content,
@@ -2685,67 +2653,38 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   .span6 .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container, .span7 .bean-stanford-postcard-linked .postcard .postcard-content,
   .span7 .bean-stanford-postcard-linked .postcard .postcard-linked-content-container,
   .span7 .bean-stanford-postcard-linked .postcard-linked-container .postcard-content,
-  .span7 .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container, .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
-  .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
-  .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
-  .span1
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
-  .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
-  .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
-  .span2
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
-  .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
-  .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
-  .span3
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
-  .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
-  .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
-  .span4
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
-  .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
-  .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
-  .span5
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
-  .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
-  .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
-  .span6
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
-  .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
-  .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
-  .span7
-  .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container {
+  .span7 .bean-stanford-postcard-linked .postcard-linked-container .postcard-linked-content-container,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
+  .span1 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
+  .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
+  .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
+  .span2 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
+  .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
+  .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
+  .span3 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
+  .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
+  .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
+  .span4 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
+  .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
+  .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
+  .span5 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
+  .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
+  .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
+  .span6 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container, .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-content,
+  .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard .postcard-linked-content-container,
+  .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-content,
+  .span7 .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container {
     width: auto;
     padding: 30px; }
 @media (max-width: 979px) {
   /* line 351, ../scss/components/_soe_beans.scss */
-  .span12 .bean-stanford-postcard-linked, .span12
-  .bean-stanford-postcard.view-mode-single_centered_button {
+  .span12 .bean-stanford-postcard-linked, .span12 .bean-stanford-postcard.view-mode-single_centered_button {
     margin: 0 10%; } }
 @media (max-width: 580px) {
   /* line 351, ../scss/components/_soe_beans.scss */
-  .span12 .bean-stanford-postcard-linked, .span12
-  .bean-stanford-postcard.view-mode-single_centered_button {
+  .span12 .bean-stanford-postcard-linked, .span12 .bean-stanford-postcard.view-mode-single_centered_button {
     margin: 0; } }
 
 @media (max-width: 979px) {
@@ -5679,15 +5618,14 @@ p.infotext {
 .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container {
   position: relative; }
   /* line 750, ../scss/components/_soe_dm_issue.scss */
-  .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container img,
-  .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container img {
+  .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container img, .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container img {
     object-fit: cover;
     object-position: center center;
     width: 100%;
     height: 100vh; }
     /* line 756, ../scss/components/_soe_dm_issue.scss */
-    .logged-in .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container img, .logged-in
-    .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container img {
+    .logged-in .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container img,
+    .logged-in .page-magazine-collections .view-stanford-magazine-issue-most-recent .mag-feat-image-container img {
       height: calc(100vh - 75px); }
   /* line 761, ../scss/components/_soe_dm_issue.scss */
   .page-magazine .view-stanford-magazine-issue-most-recent .mag-feat-image-container .mag-feat-content-container,
@@ -6474,16 +6412,13 @@ spotlight-container.no-padding.well {
     content: close-quote; }
 
 /* line 417, ../scss/components/_soe_people_spotlight.scss */
-.front .view-stanford-people-spotlight-fw-banner .spotlight-container, .front
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container, .front
-.view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container, .front
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container {
+.front .view-stanford-people-spotlight-fw-banner .spotlight-container,
+.front .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container,
+.front .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container,
+.front .view-stanford-ppl-spot-fw-banner-quote .spotlight-container {
   background: #ffffff; }
 /* line 421, ../scss/components/_soe_people_spotlight.scss */
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
-.view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
   display: flex;
   align-items: center;
   width: 50%;
@@ -6491,227 +6426,137 @@ spotlight-container.no-padding.well {
   padding: 70px 0 0; }
   @media (max-width: 1900px) {
     /* line 421, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       width: 65%; } }
   @media (max-width: 1400px) {
     /* line 421, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       width: 85%; } }
   @media (max-width: 1200px) {
     /* line 421, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       width: 90%; } }
   @media (max-width: 767px) {
     /* line 421, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       display: flex;
       text-align: left;
       width: 90%;
       padding: 50px 0 0; } }
   @media (max-width: 500px) {
     /* line 421, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
       display: block;
       text-align: center;
       width: 100%; } }
   /* line 453, ../scss/components/_soe_people_spotlight.scss */
-  .front .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .front
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .front
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container, .front
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
+  .front .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-all-content-container, .front .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-all-content-container, .front .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-all-content-container, .front .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-all-content-container {
     padding: 70px 0; }
 /* line 458, ../scss/components/_soe_people_spotlight.scss */
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img,
-.view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
   margin-right: 40px;
   flex-shrink: 0;
   order: 1; }
   @media (max-width: 767px) {
     /* line 458, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
       margin-right: 0;
       width: 286px; } }
   @media (max-width: 580px) {
     /* line 458, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
       width: 200px; } }
   @media (max-width: 500px) {
     /* line 458, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img {
       flex-shrink: 0;
       margin: 0 auto;
       width: 60%; } }
   /* line 478, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img img,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
     border-radius: 50%;
     border-width: 8px;
     border-style: solid; }
     @media (max-width: 767px) {
       /* line 478, ../scss/components/_soe_people_spotlight.scss */
-      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img,
-      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img,
-      .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img img,
-      .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
+      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
         max-width: 82%; } }
     @media (max-width: 500px) {
       /* line 478, ../scss/components/_soe_people_spotlight.scss */
-      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img,
-      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img,
-      .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img img,
-      .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
+      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img img, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img img {
         border-width: 6px; } }
   /* line 492, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-orange img,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-orange img,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img.spotlight-img-color-orange img,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-orange img {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-orange img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-orange img, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img.spotlight-img-color-orange img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-orange img {
     border-color: #ffbd54; }
   /* line 496, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img.spotlight-img-color-turquoise img,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-turquoise img {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-turquoise img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-turquoise img, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img.spotlight-img-color-turquoise img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-turquoise img {
     border-color: #00ece9; }
   /* line 500, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-pink img,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-pink img,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img.spotlight-img-color-pink img,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-pink img {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-img.spotlight-img-color-pink img, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-img.spotlight-img-color-pink img, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-img.spotlight-img-color-pink img, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-img.spotlight-img-color-pink img {
     border-color: #ff525c; }
 /* line 505, ../scss/components/_soe_people_spotlight.scss */
-.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container,
-.view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container,
-.view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container,
-.view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container {
+.view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container {
   order: 2; }
   /* line 509, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a {
     -webkit-text-decoration-skip: ink;
     text-decoration-skip: ink;
     text-decoration: underline; }
     /* line 513, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:focus, .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:hover,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:focus,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:hover,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:focus,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:hover,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:focus,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:hover {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:focus, .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:hover, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:focus, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:hover, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:focus, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:hover, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:focus, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name[class*='spotlight-name-color-'] a:hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
   /* line 519, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
     font-size: 2.4em;
     margin: 0 0 20px; }
     @media (max-width: 767px) {
       /* line 519, ../scss/components/_soe_people_spotlight.scss */
-      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2,
-      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2,
-      .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2,
-      .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
+      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
         margin-top: 15px;
         font-size: 1.7em; } }
     @media (max-width: 580px) {
       /* line 519, ../scss/components/_soe_people_spotlight.scss */
-      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2,
-      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2,
-      .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2,
-      .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
+      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
         font-size: 1.4em; } }
     @media (max-width: 480px) {
       /* line 519, ../scss/components/_soe_people_spotlight.scss */
-      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2,
-      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2,
-      .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2,
-      .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
+      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name h2, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name h2 {
         margin-bottom: 4px; } }
   /* line 537, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-orange a {
     -webkit-text-decoration-color: #ffbd54;
     text-decoration-color: #ffbd54; }
   /* line 541, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-turquoise a {
     -webkit-text-decoration-color: #00ece9;
     text-decoration-color: #00ece9; }
   /* line 545, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name.spotlight-name-color-pink a {
     -webkit-text-decoration-color: #ff525c;
     text-decoration-color: #ff525c; }
   /* line 550, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-name,
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name,
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-name,
+  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-name,
+  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-name,
   .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
     font-family: "Roboto Slab", serif; }
   /* line 555, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-degree,
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-department,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-degree,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-department,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-degree,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-department,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-degree,
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-department, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-degree,
+  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-department, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-degree,
+  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-department, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-degree,
   .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-department {
     font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif; }
   /* line 560, ../scss/components/_soe_people_spotlight.scss */
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-degree p,
   .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-department p,
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-title p,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-title p, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
   .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-department p,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-title p,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-degree p,
+  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-title p, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-degree p,
   .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-department p,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-title p,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
+  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-title p, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
   .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-department p,
   .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-title p {
     font-size: 1.2em;
@@ -6720,59 +6565,38 @@ spotlight-container.no-padding.well {
       /* line 560, ../scss/components/_soe_people_spotlight.scss */
       .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-degree p,
       .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-department p,
-      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-title p,
-      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
+      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-title p, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
       .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-department p,
-      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-title p,
-      .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-degree p,
+      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-title p, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-degree p,
       .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-department p,
-      .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-title p,
-      .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
+      .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-title p, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-degree p,
       .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-department p,
       .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-title p {
         font-size: 1em; } }
   /* line 571, ../scss/components/_soe_people_spotlight.scss */
-  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote,
-  .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote,
-  .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote,
-  .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
+  .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
     font-size: 1.4em;
     font-weight: 600;
     line-height: 1.3em;
     margin-top: 20px; }
     @media (max-width: 580px) {
       /* line 571, ../scss/components/_soe_people_spotlight.scss */
-      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote,
-      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote,
-      .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote,
-      .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
+      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
         font-size: 1.2em; } }
     @media (max-width: 500px) {
       /* line 571, ../scss/components/_soe_people_spotlight.scss */
-      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote,
-      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote,
-      .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote,
-      .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
+      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
         width: 80%;
         margin: 20px auto; } }
     @media (max-width: 480px) {
       /* line 571, ../scss/components/_soe_people_spotlight.scss */
-      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote,
-      .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote,
-      .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote,
-      .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
+      .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote {
         font-size: 1em; } }
     /* line 590, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote p::before,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote p::before,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote p::before,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote p::before {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote p::before, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote p::before, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote p::before, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote p::before {
       content: open-quote; }
     /* line 594, ../scss/components/_soe_people_spotlight.scss */
-    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote p::after,
-    .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote p::after,
-    .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote p::after,
-    .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote p::after {
+    .view-stanford-people-spotlight-fw-banner .spotlight-container .spotlight-info-container .spotlight-quote p::after, .view-stanford-people-spotlight-fw-banner-no-quote .spotlight-container .spotlight-info-container .spotlight-quote p::after, .view-stanford-ppl-spot-3-v-card.views-grid-three .view-display-id-attachment_first_spot .spotlight-container .spotlight-info-container .spotlight-quote p::after, .view-stanford-ppl-spot-fw-banner-quote .spotlight-container .spotlight-info-container .spotlight-quote p::after {
       content: close-quote; }
 
 /* line 605, ../scss/components/_soe_people_spotlight.scss */

--- a/scss/components/_soe_wysiwyg.scss
+++ b/scss/components/_soe_wysiwyg.scss
@@ -3,6 +3,35 @@
 // WYSIWYG
 //
 
+
+
+.image-caption-right,
+.image-caption-left {
+  margin: 0px;
+  padding: 0px;
+  border: 0;
+  float: none;
+  width: 100%;
+  color: #606060;
+  font-size: 16px;
+  line-height: 1.3em;
+  font-weight: 300;
+}
+
+.image-caption-right {
+  float: right;
+  width: 10em;
+  padding: 0em 0em 0em 1.5em;
+  margin: 1em 0em 1em 1.5em;
+}
+
+.image-caption-left {
+  float: left;
+  width: 10em;
+  padding: 0em 1.5em 0em 0em;
+  margin: 1em 1.5em 0em 0em;
+}
+
 .summary {
   font-family: $roboto-slab;
   font-size: em(32px);
@@ -146,6 +175,18 @@ p.columns {
       padding: 0 50px;
     }
   }
+}
+
+p.float-left,
+p.float-right {
+  float: none;
+  margin: 0px;
+  padding: 0px;
+  width: 100%;
+}
+
+p.float-right,
+  .image-caption-right {
 }
 
 p.related-link {

--- a/scss/components/_soe_wysiwyg.scss
+++ b/scss/components/_soe_wysiwyg.scss
@@ -3,8 +3,6 @@
 // WYSIWYG
 //
 
-
-
 .image-caption-right,
 .image-caption-left {
   margin: 0px;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
_See ticket: https://stanfordits.atlassian.net/browse/SOE-3477_
This adds styles so we can have captions on images in the WYSIWYG

# Needed By (Date)
- Code Freeze


# Criticality
- Client is eagerly awaiting this.

# Steps to Test
## Check out this branch
`git checkout 7.x-2.x-SOE-3446-caption`

## Update site through the UI
Add Image Caption styles to WYSIWYG filter at: 
`admin/config/content/wysiwyg/profile/content_editor_text_format/edit`

```
Image Caption Right=div.image-caption-right
Image Caption Left=div.image-caption-left
```

Add to **Rules for class names** at: `admin/config/content/formats/content_editor_text_format`

```
image-caption-right,
image-caption-left
```
## Check it out
1. Insert your image
2. Highlight your image, add the "Image left" or "Image right" style from the style dropdown
3. Hit shift+enter to the line below your image
4. Type in your caption
5. Highlight both the image and the caption text, add the "image and caption" style from the style dropdown

![screen shot 2018-09-12 at 12 47 39](https://user-images.githubusercontent.com/284440/45449440-12166600-b68a-11e8-98ef-e03f9183ccc1.png)


# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
PR: https://stanfordits.atlassian.net/browse/SOE-3477
Documentation & Discussion: https://stanfordits.atlassian.net/browse/SOE-3446

## Related PRs

## More Information

## Folks to notify
`@annawatt `
`@kerri-augenstein `


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)