### PR TITLE
SOE-3562 Injector 78

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,6 @@ module.exports = function(grunt) {
     }
   });
   grunt.loadNpmTasks('grunt-sass');
-  grunt.loadNpmTasks('grunt-contrib-sass');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.registerTask('default', ['watch']);
 }

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -271,9 +271,17 @@ th {
   float: none;
   width: 100%;
   color: #606060;
-  font-size: 16px;
+  font-size: 0.8em;
   line-height: 1.3em;
-  font-weight: 300; }
+  font-weight: 300;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box; }
+  .image-caption-right img,
+  .image-caption-left img {
+    height: auto;
+    margin-bottom: 0.75em;
+    width: 100%; }
 
 .image-caption-right {
   float: right;

--- a/package.json
+++ b/package.json
@@ -18,11 +18,10 @@
   },
   "devDependencies": {
     "grunt": "^1.0.3",
-    "grunt-contrib-sass": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-sass": "^2.1.0"
   },
   "dependencies": {
-    "node-sass": "^4.9.3"
+    "node-sass": "^4.10.0"
   }
 }

--- a/scss/components/_soe_wysiwyg.scss
+++ b/scss/components/_soe_wysiwyg.scss
@@ -11,9 +11,17 @@
   float: none;
   width: 100%;
   color: #606060;
-  font-size: 16px;
+  font-size: em(16px);
   line-height: 1.3em;
   font-weight: 300;
+
+  @include box-sizing(border-box);
+
+  & img {
+    height: auto;
+    margin-bottom: 0.75em;
+    width: 100%;
+  }
 }
 
 .image-caption-right {
@@ -181,10 +189,6 @@ p.float-right {
   margin: 0px;
   padding: 0px;
   width: 100%;
-}
-
-p.float-right,
-  .image-caption-right {
 }
 
 p.related-link {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Moved CSS from Injector Rule 78 into SCSS (some was already there; added and cleaned up the rest)
- Removed `gront-contrib-sass` in favor of `grunt-sass` to remove dependency on Ruby

# Needed By (Date)
- End of sprint (11/9)

# Urgency
- HN/A

# Steps to Test

1. Pull this branch
2. Review code for accuracy

# Affected Projects or Products
- Engineering
- `stanford_sor_helper`

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-3562

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)