### PR TITLE
Moved CSS from Injector Rule 86 into SCSS

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -4691,6 +4691,9 @@ p.infotext {
       #block-ds-extras-related-departments .field-name-field-s-mag-article-dept {
         width: 100%; } }
 
+.page-taxonomy-term #block-stanford-soe-helper-magazine-soe-all-issues-link-2 {
+  display: none; }
+
 .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container {
   position: relative; }
   .node-type-stanford-magazine-issue .view-stanford-magazine-issue-featured-article .mag-feat-image-container img {

--- a/scss/components/_soe_dm_article.scss
+++ b/scss/components/_soe_dm_article.scss
@@ -1144,3 +1144,7 @@
     }
   }
 }
+
+.page-taxonomy-term #block-stanford-soe-helper-magazine-soe-all-issues-link-2 {
+  display: none;
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Moved CSS from Injector Rule 86 into SCSS

# Needed By (Date)
- End of sprint (11/9)

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. Disable this injector `admin/config/development/css-injector/edit/86`
2. Review code for accuracy

# Affected Projects or Products
- Engineering
- `stanford_soe_helper`

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-3719

## Related PRs

## More Information

## Folks to notify
@boznik 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)