### PR TITLE
SOE-3465: Fix signup block placement

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -74,6 +74,8 @@ plugins:
         enabled: false
       CyclomaticComplexity:
         enabled: false
+      Design/NpathComplexity:
+        enabled: false
       UnusedFormalParameter:
         enabled: false
     config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -72,6 +72,8 @@ plugins:
         enabled: false
       CleanCode/BooleanArgumentFlag:
         enabled: false
+      CyclomaticComplexity:
+        enabled: false
       UnusedFormalParameter:
         enabled: false
     config:
@@ -84,6 +86,9 @@ plugins:
   # https://docs.codeclimate.com/docs/phan
   phan:
     enabled: true
+    checks:
+          PhanTypeInvalidDimOffset:
+            enabled: false
     config:
       file_extensions: "php,module,profile,inc"
       # minimum-severity: 1

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -3772,6 +3772,9 @@ p.infotext {
 .node-type-stanford-magazine-article #block-views-791d235d18b47f6352dcdf232609d31b + div {
   background-color: #efefef; }
 
+.node-type-stanford-magazine-article #content-bottom #block-bean-stanford-soe-mag-news-signup {
+  padding-bottom: 0; }
+
 .node-type-stanford-magazine-article #block-bean-stanford-soe-mag-news-signup {
   padding-bottom: 80px; }
   .node-type-stanford-magazine-article #block-bean-stanford-soe-mag-news-signup .mailchimp-magazine-block #mc_embed_signup_scroll {

--- a/scss/components/_soe_dm_article.scss
+++ b/scss/components/_soe_dm_article.scss
@@ -234,7 +234,7 @@
   #content-bottom #block-bean-stanford-soe-mag-news-signup {
     padding-bottom: 0;
   }
-  
+
   #block-bean-stanford-soe-mag-news-signup {
     padding-bottom: 80px;
 

--- a/scss/components/_soe_dm_article.scss
+++ b/scss/components/_soe_dm_article.scss
@@ -231,6 +231,10 @@
     background-color: $light-gray;
   }
 
+  #content-bottom #block-bean-stanford-soe-mag-news-signup {
+    padding-bottom: 0;
+  }
+  
   #block-bean-stanford-soe-mag-news-signup {
     padding-bottom: 80px;
 

--- a/stanford_soe_helper.module
+++ b/stanford_soe_helper.module
@@ -83,15 +83,17 @@ user/*/edit";
   $collections = 0;
 
   // If the page is part of a collection, take note.
-  foreach ($variables['page']['content']['system_main']['nodes'] as $node) {
-    if (isset($node['field_s_mag_article_collection'])) {
-      $collections++;
+  if (isset($variables['page']['content']['system_main']['nodes'])) {
+    foreach ($variables['page']['content']['system_main']['nodes'] as $node) {
+      if (isset($node['field_s_mag_article_collection'])) {
+        $collections++;
+      }
     }
   }
 
   // Move the mag news signup between related depts and related articles.
   if (!$collections) {
-    if (isset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'])) {
+    if (isset($variables['page']['content_bottom']) && isset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'])) {
       array_unshift($variables['page']['content_bottom'], $variables['page']['fullwidth_bottom']);
       unset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup']);
     }

--- a/stanford_soe_helper.module
+++ b/stanford_soe_helper.module
@@ -80,14 +80,16 @@ user/*/edit";
     }
   }
 
-  $collections = 0;
+  $collections = FALSE;
 
   // If the page is part of a collection, take note.
   if (isset($variables['page']['content']['system_main']['nodes'])) {
-    foreach ($variables['page']['content']['system_main']['nodes'] as $node) {
-      if (isset($node['field_s_mag_article_collection'])) {
-        $collections++;
-      }
+
+    $nodes = array_pop(array_reverse($variables['page']['content']['system_main']));
+    $node = array_pop(array_reverse($nodes));
+
+    if (isset($node['field_s_mag_article_collection'])) {
+      $collections = TRUE;
     }
   }
 

--- a/stanford_soe_helper.module
+++ b/stanford_soe_helper.module
@@ -95,7 +95,8 @@ user/*/edit";
   if (!$collections) {
     if (isset($variables['page']['content_bottom']) && isset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'])) {
       // Move the mag news signup between related depts and related articles.
-      array_unshift($variables['page']['content_bottom'], $variables['page']['fullwidth_bottom']);
+      $signup = $variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'];
+      $variables['page']['content_bottom'] = array('bean_stanford-soe-mag-news-signup' => $signup) + $variables['page']['content_bottom'];
       // Unset the block from showing in the fullwidth bottom region.
       unset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup']);
     }

--- a/stanford_soe_helper.module
+++ b/stanford_soe_helper.module
@@ -84,19 +84,19 @@ user/*/edit";
 
   // If the page is part of a collection, take note.
   if (isset($variables['page']['content']['system_main']['nodes'])) {
-
-    $nodes = array_pop(array_reverse($variables['page']['content']['system_main']));
-    $node = array_pop(array_reverse($nodes));
-
-    if (isset($node['field_s_mag_article_collection'])) {
-      $collections = TRUE;
+    foreach ($variables['page']['content']['system_main']['nodes'] as $node) {
+      if (isset($node['field_s_mag_article_collection'])) {
+        $collections = TRUE;
+      }
     }
   }
 
-  // Move the mag news signup between related depts and related articles.
+  // If we are on a mag article that is not part of a collection.
   if (!$collections) {
-    if (isset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'])) {
+    if (isset($variables['page']['content_bottom']) && isset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'])) {
+      // Move the mag news signup between related depts and related articles.
       array_unshift($variables['page']['content_bottom'], $variables['page']['fullwidth_bottom']);
+      // Unset the block from showing in the fullwidth bottom region.
       unset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup']);
     }
   }

--- a/stanford_soe_helper.module
+++ b/stanford_soe_helper.module
@@ -95,8 +95,7 @@ user/*/edit";
   if (!$collections) {
     if (isset($variables['page']['content_bottom']) && isset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'])) {
       // Move the mag news signup between related depts and related articles.
-      $signup = $variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'];
-      $variables['page']['content_bottom'] = array('bean_stanford-soe-mag-news-signup' => $signup) + $variables['page']['content_bottom'];
+      array_unshift($variables['page']['content_bottom'], $variables['page']['fullwidth_bottom']);
       // Unset the block from showing in the fullwidth bottom region.
       unset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup']);
     }

--- a/stanford_soe_helper.module
+++ b/stanford_soe_helper.module
@@ -93,7 +93,7 @@ user/*/edit";
 
   // Move the mag news signup between related depts and related articles.
   if (!$collections) {
-    if (isset($variables['page']['content_bottom']) && isset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'])) {
+    if (isset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'])) {
       array_unshift($variables['page']['content_bottom'], $variables['page']['fullwidth_bottom']);
       unset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup']);
     }

--- a/stanford_soe_helper.module
+++ b/stanford_soe_helper.module
@@ -79,6 +79,23 @@ user/*/edit";
       ];
     }
   }
+
+  $collections = 0;
+
+  // If the page is part of a collection, take note.
+  foreach ($variables['page']['content']['system_main']['nodes'] as $node) {
+    if (isset($node['field_s_mag_article_collection'])) {
+      $collections++;
+    }
+  }
+
+  // Move the mag news signup between related depts and related articles.
+  if (!$collections) {
+    if (isset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'])) {
+      array_unshift($variables['page']['content_bottom'], $variables['page']['fullwidth_bottom']);
+      unset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup']);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Push Email Subscribe block back up on Mag Article node (except on Collection Node)

# Needed By (Date)
- ?

# Urgency
- N/A

# Steps to Test

1. Go to: `magazine/article/new-ai-camera-recognizes-objects-faster-and-more-efficiently` and `magazine/article/dan-boneh-still-early-days-blockchain-rich-possibility`.
2. See the email signup block above the footer on both pages.
3. Checkout this branch.
4. `drush cc all`
5. Go to: `magazine/article/new-ai-camera-recognizes-objects-faster-and-more-efficiently`.
6. The email subscribe block should now be under "Related Departments" and above "Related Articles".
7. Go to: `magazine/article/dan-boneh-still-early-days-blockchain-rich-possibility`
8. The email subscribe block should be under "Related Articles" as this article is part of a collection.

# Affected Projects or Products
- Engineering
- `stanford_soe_helper`

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-3465

## Related PRs

## More Information

## Folks to notify
@boznik 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)