### PR TITLE
SOE-3465: Fixing bug on Topic pages with signup block

### DIFF
--- a/stanford_soe_helper.module
+++ b/stanford_soe_helper.module
@@ -95,7 +95,9 @@ user/*/edit";
   if (!$collections) {
     if (isset($variables['page']['content_bottom']) && isset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup'])) {
       // Move the mag news signup between related depts and related articles.
-      array_unshift($variables['page']['content_bottom'], $variables['page']['fullwidth_bottom']);
+      if (!isset($variables['page']['full_width_middle']['bean_stanford-soe-mag-news-signup'])) {
+        array_unshift($variables['page']['content_bottom'], $variables['page']['fullwidth_bottom']);
+      }
       // Unset the block from showing in the fullwidth bottom region.
       unset($variables['page']['fullwidth_bottom']['bean_stanford-soe-mag-news-signup']);
     }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixes bug where it adds the block when it's already in the middle.

# Needed By (Date)
- NOW

# Urgency
- HIGH

# Steps to Test

1. Go to: `magazine/article/new-ai-camera-recognizes-objects-faster-and-more-efficiently` and `magazine/article/dan-boneh-still-early-days-blockchain-rich-possibility`.
2. See the email signup block above the footer on both pages.
3. Checkout this branch.
4. `drush cc all`
5. Go to: `magazine/article/new-ai-camera-recognizes-objects-faster-and-more-efficiently`.
6. The email subscribe block should now be under "Related Departments" and above "Related Articles".
7. Go to: `magazine/article/dan-boneh-still-early-days-blockchain-rich-possibility`
8. The email subscribe block should be under "Related Articles" as this article is part of a collection.

# Affected Projects or Products
- Engineering
- `stanford_soe_helper`

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-3465

## Related PRs

## More Information

## Folks to notify
@boznik 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)