### PR TITLE
SITES-3746: Put injector 96 into code

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -1709,6 +1709,24 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
 .view-soe-school-news-with-teaser {
   margin-top: 12px; }
 
+.view-soe-school-news-with-teaser.view-display-id-page_1.views-row-lines .views-row {
+  padding: 1em 1.5em 1.7em;
+  margin-bottom: 0px; }
+
+.view-soe-school-news-with-teaser.view-display-id-page_1.views-row-lines .views-row-1 {
+  padding: 1em 1.5em 1.7em; }
+
+.view-soe-school-news-with-teaser.view-display-id-page_1 .item-list .pager {
+  margin-top: 2em; }
+  .view-soe-school-news-with-teaser.view-display-id-page_1 .item-list .pager li a {
+    font-size: 0.8em; }
+    .view-soe-school-news-with-teaser.view-display-id-page_1 .item-list .pager li a:focus, .view-soe-school-news-with-teaser.view-display-id-page_1 .item-list .pager li a:hover {
+      background-color: #8c1515;
+      font-weight: 400; }
+
+.view-soe-school-news-with-teaser.view-display-id-page_1 .views-row {
+  margin-bottom: 0px; }
+
 .node-type-stanford-event .date-display-single {
   font-weight: 600; }
 

--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -1710,8 +1710,8 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   margin-top: 12px; }
 
 .view-soe-school-news-with-teaser.view-display-id-page_1.views-row-lines .views-row {
-  padding: 1em 1.5em 1.7em;
-  margin-bottom: 0px; }
+  margin-bottom: 0px;
+  padding: 1em 1.5em 1.7em; }
 
 .view-soe-school-news-with-teaser.view-display-id-page_1.views-row-lines .views-row-1 {
   padding: 1em 1.5em 1.7em; }

--- a/scss/components/_soe_news.scss
+++ b/scss/components/_soe_news.scss
@@ -301,7 +301,7 @@
 .view-soe-school-news-with-teaser.view-display-id-page_1 {
   &.views-row-lines {
     .views-row {
-      margin-bottom: 0px;
+      margin-bottom: 0;
       padding: 1em 1.5em 1.7em;
     }
 
@@ -325,6 +325,6 @@
   }
 
   .views-row {
-    margin-bottom: 0px;
+    margin-bottom: 0;
   }
 }

--- a/scss/components/_soe_news.scss
+++ b/scss/components/_soe_news.scss
@@ -297,3 +297,34 @@
 .view-soe-school-news-with-teaser {
   margin-top: 12px;
 }
+
+.view-soe-school-news-with-teaser.view-display-id-page_1 {
+  &.views-row-lines {
+    .views-row {
+      padding: 1em 1.5em 1.7em;
+      margin-bottom: 0px;
+    }
+
+    .views-row-1 {
+      padding: 1em 1.5em 1.7em;
+    }
+  }
+
+  .item-list .pager {
+    margin-top: 2em;
+
+    li a {
+      font-size: 0.8em;
+
+      &:focus,
+      &:hover {
+        background-color: $brand;
+        font-weight: 400;
+      }
+    }
+  }
+
+  .views-row {
+    margin-bottom: 0px;
+  }
+}

--- a/scss/components/_soe_news.scss
+++ b/scss/components/_soe_news.scss
@@ -301,8 +301,8 @@
 .view-soe-school-news-with-teaser.view-display-id-page_1 {
   &.views-row-lines {
     .views-row {
-      padding: 1em 1.5em 1.7em;
       margin-bottom: 0px;
+      padding: 1em 1.5em 1.7em;
     }
 
     .views-row-1 {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Moved CSS from Injector Rule 96 into SCSS/CSS

# Needed By (Date)
- End of sprint (12/21)

# Urgency
- 4/10

# Steps to Test

1. Go to: `news/school-news`
2. Turn off injector 96 here: `admin/config/development/css-injector/edit/96`
3. Note style changes on the rows when the injector is toggled on and off.
4. While the injector is off, pull this branch.
5. `drush cc all`
6. Refresh school-news page and make sure the injector changes took to code.
7. Have a cold one 🍺 


# Affected Projects or Products
- Engineering
- `stanford_soe_helper`

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-3746

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)