### PR TITLE
Soe 3762 teal underlines

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -1186,10 +1186,10 @@ p.summary.drop-cap:first-letter {
   .front [id*='block-bean-homepage-2-column-'] .content a:not(.btn) {
     -webkit-text-decoration-skip: ink;
     text-decoration-skip: ink;
-    -webkit-text-decoration-color: #00ece9;
-    text-decoration-color: #00ece9;
     color: #333333;
-    text-decoration: underline; }
+    text-decoration: underline;
+    -webkit-text-decoration-color: #00ece9;
+    text-decoration-color: #00ece9; }
     .front [id*='block-bean-homepage-2-column-'] .content a:not(.btn):focus, .front [id*='block-bean-homepage-2-column-'] .content a:not(.btn):hover {
       -webkit-text-decoration-color: #333333;
       text-decoration-color: #333333; }
@@ -2177,14 +2177,14 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
       .bean-stanford-postcard.view-mode-single_centered_button .postcard-linked-container .postcard-linked-content-container .postcard-linked-title a {
         -webkit-text-decoration-skip: ink;
         text-decoration-skip: ink;
-        -webkit-text-decoration-color: #00ece9;
-        text-decoration-color: #00ece9;
         color: #333333;
         font-family: "Roboto Slab", serif;
         font-size: 1.4em;
         font-weight: 600;
         letter-spacing: 0.02em;
-        text-decoration: underline; }
+        text-decoration: underline;
+        -webkit-text-decoration-color: #00ece9;
+        text-decoration-color: #00ece9; }
         @media (max-width: 979px) {
           .bean-stanford-postcard-linked .postcard .postcard-content .field-name-title a,
           .bean-stanford-postcard-linked .postcard .postcard-content .postcard-linked-title a,

--- a/scss/components/_soe_beans.scss
+++ b/scss/components/_soe_beans.scss
@@ -297,7 +297,7 @@
           text-decoration: underline;
 
           @include td-color($turquoise);
-          
+
           @include breakpoint-max(medium) {
             margin-top: 20px;
           }

--- a/scss/components/_soe_beans.scss
+++ b/scss/components/_soe_beans.scss
@@ -288,7 +288,6 @@
 
         a {
           @include td-skip;
-          @include td-color($turquoise);
 
           color: $primary-color;
           font-family: $roboto-slab;
@@ -296,6 +295,8 @@
           font-weight: 600;
           letter-spacing: 0.02em;
           text-decoration: underline;
+
+          @include td-color($turquoise);
 
           @include breakpoint-max(medium) {
             margin-top: 20px;

--- a/scss/components/_soe_beans.scss
+++ b/scss/components/_soe_beans.scss
@@ -297,7 +297,7 @@
           text-decoration: underline;
 
           @include td-color($turquoise);
-
+          
           @include breakpoint-max(medium) {
             margin-top: 20px;
           }

--- a/scss/components/_soe_homepage.scss
+++ b/scss/components/_soe_homepage.scss
@@ -21,10 +21,10 @@
 
       a:not(.btn) {
         @include td-skip;
-        @include td-color($turquoise);
 
         color: $primary-color;
         text-decoration: underline;
+        @include td-color($turquoise);
 
         &:focus,
         &:hover {

--- a/scss/components/_soe_homepage.scss
+++ b/scss/components/_soe_homepage.scss
@@ -24,7 +24,6 @@
 
         color: $primary-color;
         text-decoration: underline;
-        
         @include td-color($turquoise);
 
         &:focus,

--- a/scss/components/_soe_homepage.scss
+++ b/scss/components/_soe_homepage.scss
@@ -24,6 +24,7 @@
 
         color: $primary-color;
         text-decoration: underline;
+        
         @include td-color($turquoise);
 
         &:focus,


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed teal underlines missing from homepage big-text + postcard blocks

# Needed By (Date)
- End of sprint (12/21)

# Urgency
- 8/10

# Steps to Test

1. Go to the homepage
3. Note the screenshots in the associated ticket SOE-3762.
4. Pull this branch.
5. `drush cc all`
6. Refresh homepage and see the underlines work again.
7. Have a warm one ☕️ 


# Affected Projects or Products
- Engineering
- `stanford_soe_helper`

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-3762

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)