### PR TITLE
SOE-3793 Caption Credits Font Size

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -1560,7 +1560,7 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   margin-top: 1em; }
 
 .node-type-stanford-news-item .caption {
-  font-size: 0.7em;
+  font-size: 0.9em;
   font-style: normal; }
   .node-type-stanford-news-item .caption p:after {
     padding-right: 3px; }

--- a/scss/components/_soe_news.scss
+++ b/scss/components/_soe_news.scss
@@ -68,7 +68,7 @@
   }
 
   .caption {
-    font-size: 0.9em;
+    font-size: em(18px);
     font-style: normal;
 
     p:after {

--- a/scss/components/_soe_news.scss
+++ b/scss/components/_soe_news.scss
@@ -68,7 +68,7 @@
   }
 
   .caption {
-    font-size: 0.7em;
+    font-size: 0.9em;
     font-style: normal;
 
     p:after {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Ups the font size for captions/credits on News nodes

# Needed By (Date)
- End of sprint (2/1)

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. Clear caches
3. Verify that the font size for captions/credits on a news node with an image is `.9em` (`18px`).

# Affected Projects or Products
- stanford_soe_helper
- Engineering

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-3793

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)