### PR TITLE
SOE-3669: Fix Research & Ideas header way too tall on mobile

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -3512,12 +3512,19 @@ p.infotext {
         #digital-magazine-menu .region-digital-magazine-menu .block-menu-block {
           display: block;
           width: 100%; } }
+      @media (max-width: 580px) {
+        #digital-magazine-menu .region-digital-magazine-menu .block-menu-block {
+          padding-top: 10px; } }
       #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2 {
         margin-bottom: 0;
         padding-bottom: 20px; }
         @media (max-width: 767px) {
           #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2 {
             float: left; } }
+        @media (max-width: 580px) {
+          #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2 {
+            font-size: 22px;
+            padding-bottom: 10px; } }
         #digital-magazine-menu .region-digital-magazine-menu .block-menu-block h2 a {
           font-weight: 600;
           text-decoration: none; }
@@ -3576,6 +3583,9 @@ p.infotext {
             #digital-magazine-menu .region-digital-magazine-menu .block-menu-block ul li a.active {
               color: #606060;
               border-bottom-color: #606060; }
+    @media (max-width: 767px) {
+      #digital-magazine-menu .region-digital-magazine-menu .block-stanford-search-api {
+        margin-top: -10px; } }
     #digital-magazine-menu .region-digital-magazine-menu .block-stanford-search-api .form-item-keywords {
       margin-top: 1.1em; }
       @media (max-width: 767px) {

--- a/scss/components/_soe_dm_navigation.scss
+++ b/scss/components/_soe_dm_navigation.scss
@@ -67,12 +67,21 @@
         width: 100%;
       }
 
+      @include breakpoint-max(smaller) {
+        padding-top: 10px;
+      }
+
       h2 {
         margin-bottom: 0;
         padding-bottom: 20px;
 
         @include breakpoint-max(small) {
           float: left;
+        }
+
+        @include breakpoint-max(smaller) {
+          font-size: 22px;
+          padding-bottom: 10px;
         }
 
         a {
@@ -173,6 +182,11 @@
     }
 
     .block-stanford-search-api {
+
+      @include breakpoint-max(small) {
+        margin-top: -10px;
+      }
+
       .form-item-keywords {
         margin-top: 1.1em;
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Made some scss/css changes to fix the ticket for Research & Ideas header way too tall on mobile.

# Needed By (Date)
- 03/19

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. Review code for accuracy

# Affected Projects or Products
- Engineering
- `stanford_soe_helper`

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-3669

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)