### PR TITLE
SOEOP-71: fix margin at 1200px width

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -5904,6 +5904,7 @@ spotlight-container.no-padding.well {
     .view-stanford-ppl-spot-2-v-span4-card.views-grid-three .views-row,
     .view-stanford-ppl-spot-2-v-span6-card.views-grid-three .views-row,
     .view-stanford-ppl-spot-3-v-card.views-grid-three .views-row {
+      margin-right: 3%;
       width: 46.1%; } }
   @media (max-width: 580px) {
     .view-stanford-people-spot-1-vertical-span6-card.views-grid-three .views-row,

--- a/scss/components/_soe_people_spotlight.scss
+++ b/scss/components/_soe_people_spotlight.scss
@@ -308,6 +308,7 @@ spotlight-container.no-padding.well {
     margin-bottom: 80px;
 
     @media (max-width: 1200px) {
+      margin-right: 3%;
       width: 46.1%;
     }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
_See ticket:_ https://stanfordits.atlassian.net/browse/SOEOP-71
This fixes the margins for spotlights at 1200px width

# Needed By (Date)
soon

# Criticality
- Fixes broken stuff


# Steps to Test
- Checkout this branch
- Verify that the margin on all the spotlight cards looks right at less that 1200px

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s): https://stanfordits.atlassian.net/browse/SOEOP-71

## Related PRs

## More Information
@minorwm Because I don't have an SoE site running locally I'm taking an educated guess that this will fix the margins, but I have not tested this.

## Folks to notify
@rmundstock 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)