### PR TITLE
SOEOP-175: add fix to date

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -4656,6 +4656,10 @@ p.infotext {
         color: #fbfbf9;
         text-decoration: none; }
 
+.view-stanford-magazine-collection-mag-landing-page.view-display-id-collection_group_block_1 .mag-article-container .mag-article-content-container .mag-article-date {
+  line-height: 2;
+  padding-right: 10px; }
+
 .view-display-id-article_collection_bottom_block .mag-article-container .mag-article-content-container .mag-article-title a {
   font-weight: 600; }
 

--- a/scss/components/_soe_dm_article.scss
+++ b/scss/components/_soe_dm_article.scss
@@ -947,6 +947,18 @@
   }
 }
 
+// Specific spacing and alignment for the date on landing page top
+.view-stanford-magazine-collection-mag-landing-page.view-display-id-collection_group_block_1 {
+  .mag-article-container {
+    .mag-article-content-container {
+      .mag-article-date {
+        line-height: 2;
+        padding-right: 10px;
+      }
+    }
+  }
+}
+
 .view-display-id-article_collection_bottom_block {
   .mag-article-container {
     .mag-article-content-container {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
This fixes alignment and spacing on the date.
_See ticket: https://stanfordits.atlassian.net/browse/SOEOP-175_ 

# Needed By (Date)
- 12/11/2019
_For release: https://stanfordits.atlassian.net/browse/SOEOP-172_

# Criticality
- Fixes broken stuff


# Steps to Test
- Checkout this branch
- Navigate to /magazine/future-everything?page=5
- Verify you see space between the date and the article title:
![Screen Shot 2019-11-13 at 6 47 56 PM](https://user-images.githubusercontent.com/284440/68822809-c1601b80-0646-11ea-8433-422340fb59ea.png)


# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOEOP-175

## Related PRs

## More Information

## Folks to notify
@rmundstock 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)