### PR TITLE
SOEOP-179: removed extra path in view

### DIFF
--- a/modules/stanford_soe_helper_news/stanford_soe_helper_news.views_default.inc
+++ b/modules/stanford_soe_helper_news/stanford_soe_helper_news.views_default.inc
@@ -128,17 +128,14 @@ function stanford_soe_helper_news_views_default_views() {
   $handler->display->display_options['fields']['nothing']['field'] = 'nothing';
   $handler->display->display_options['fields']['nothing']['label'] = '';
   $handler->display->display_options['fields']['nothing']['alter']['text'] = '<div class="feat-news-container">
-  <a href=[path]>
-      <div class="feat-news-img">[field_s_image_info]</div>
-  </a>
-      <div class="feat-news-content-container">
-           <div class="feat-news-date">School News – [field_s_news_date]</div>
-           <div class="feat-news-title"><h2>[title]</h2></div>
-           <div class="feat-news-teaser">[field_s_news_teaser]</div>
-           <div class="edit-link">[edit_node]</div>
-      </div>
- </div>
-';
+    <div class="feat-news-img">[field_s_image_info]</div>
+    <div class="feat-news-content-container">
+        <div class="feat-news-date">School News – [field_s_news_date]</div>
+        <div class="feat-news-title"><h2>[title]</h2></div>
+        <div class="feat-news-teaser">[field_s_news_teaser]</div>
+        <div class="edit-link">[edit_node]</div>
+    </div>
+</div>';
   $handler->display->display_options['fields']['nothing']['element_type'] = 'div';
   $handler->display->display_options['fields']['nothing']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['nothing']['element_wrapper_type'] = 'div';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
There were two nested URLs linking the image breaking the HTML. This should fix it.
_See ticket https://stanfordits.atlassian.net/browse/SOEOP-179:_ 

# Needed Review By (Date)
12/11/2019
_For version release: https://stanfordits.atlassian.net/browse/SOEOP-172_

# Criticality
- Fixes broken stuff

# Steps to Test
- Checkout this branch
- May need to revert feature stanford_soe_helper_news
- Navigate to the home page and make sure the image in the news block near the bottom, center of the page still links to the node page.
- Go to https://validator.w3.org/ and verify you see don't see:
```
Error: Start tag a seen but an element of the same type was already open.

From line 377, column 34; to line 377, column 111

news-img"><a href="/news/walter-vincenti-whose-insights-led-supersonic-flight-dies-102"><div c

Error: End tag a violates nesting rules.

From line 377, column 34; to line 377, column 111

news-img"><a href="/news/walter-vincenti-whose-insights-led-supersonic-flight-dies-102"><div c

Fatal Error: Cannot recover after last error. Any further errors will be ignored.

From line 377, column 34; to line 377, column 111

news-img"><a href="/news/walter-vincenti-whose-insights-led-supersonic-flight-dies-102"><div c

```
# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOEOP-179

## Related PRs

## More Information

## Folks to notify


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)