### PR TITLE
SOEOP-197: responsive fixes to news

### DIFF
--- a/css/soe_helper.css
+++ b/css/soe_helper.css
@@ -1551,7 +1551,8 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
   margin-bottom: 0; }
 
 .node-type-stanford-news-item .body-style {
-  width: 750px; }
+  max-width: 750px;
+  width: 100%; }
 
 @media (min-width: 979px) {
   .node-type-stanford-news-item .postcard-image {
@@ -1595,20 +1596,22 @@ body:not(.page-admin) .sidebar .views-exposed-form .views-exposed-widget .form-s
     display: block; } }
 
 #block-ds-extras-banner-overlay {
-  width: 750px;
+  max-width: 750px;
+  width: 100%;
   position: absolute;
   top: 210px; }
   @media (max-width: 1200px) {
     #block-ds-extras-banner-overlay {
+      max-width: 600px;
       top: 250px; } }
   @media (max-width: 767px) {
     #block-ds-extras-banner-overlay {
       position: relative;
-      top: -196px;
+      top: -260px;
       margin-bottom: -245px; } }
   @media (max-width: 580px) {
     #block-ds-extras-banner-overlay {
-      top: -224px; } }
+      top: -340px; } }
   @media (max-width: 480px) {
     #block-ds-extras-banner-overlay {
       width: 100%; } }

--- a/scss/components/_soe_news.scss
+++ b/scss/components/_soe_news.scss
@@ -18,7 +18,8 @@
   }
 
   .body-style {
-    width: 750px;
+    max-width: 750px;
+    width: 100%;
 
     @include breakpoint-max(med-small) {
       width: 100%;
@@ -99,11 +100,13 @@
 }
 
 #block-ds-extras-banner-overlay {
-  width: 750px;
+  max-width: 750px;
+  width: 100%;
   position: absolute;
   top: 210px;
 
   @include breakpoint-max(large) {
+    max-width: 600px;
     top: 250px;
   }
 
@@ -114,12 +117,12 @@
 
   @include breakpoint-max(small) {
     position: relative;
-    top: -196px;
+    top: -260px;
     margin-bottom: -245px;
   }
 
   @include breakpoint-max(smaller) {
-    top: -224px;
+    top: -340px;
   }
 
   @include breakpoint-max(x-small) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
This fixes responsive issues for news pages.
_See ticket: https://stanfordits.atlassian.net/browse/SOEOP-197_ 

# Needed Review By (Date)
12/11/2019
_For next release: https://stanfordits.atlassian.net/browse/SOEOP-172_

# Criticality
- Client is eagerly awaiting this.
- Fixes broken stuff


# Steps to Test
- Checkout this branch
- Navigate to /news/james-spilker-jr-father-gps-has-died-86
- Verify you see body text, header, and dek all behave nicely and stay within their bounds

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
See ticket: https://stanfordits.atlassian.net/browse/SOEOP-197
https://stanfordits.atlassian.net/browse/SOEOP-172

## Related PRs
None

## More Information

## Folks to notify
@rmundstock 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)